### PR TITLE
feat(process): require coding prompt in every ticket for agent handoff

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,108 @@
+name: Bug Report
+description: Report a bug with a coding prompt for automated agent handoff
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Bug Report with Coding Prompt
+
+        This template requires a **coding prompt** — a self-contained specification with exact file paths, line numbers, current code, replacement code, and reasoning. Coding agents (Codex, Devin, Cursor Agent) rely on this to produce correct changes without exploring the codebase.
+
+        **Without a coding prompt, your issue will be auto-labeled `missing-coding-prompt`.**
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: What's broken? What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this bug?
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What should happen instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happens?
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Node version, browser, etc.
+      placeholder: |
+        - OS: 
+        - Node: 
+        - Browser: 
+    validations:
+      required: false
+
+  - type: textarea
+    id: coding_prompt
+    attributes:
+      label: Coding Prompt
+      description: |
+        **Required.** Self-contained specification for coding agents. Include:
+        - **File path** — exact file(s) to modify
+        - **Current code** — the code as it exists now (with line numbers)
+        - **Replacement code** — the new code
+        - **Reasoning** — why this change fixes the bug
+
+        Example:
+        ```markdown
+        ## File: src/routes/chat.ts (line 45-52)
+
+        ### Current Code
+        ```typescript
+        const health = await checkHealth();
+        console.log(health);
+        // Missing: UI update
+        ```
+
+        ### Replacement Code
+        ```typescript
+        const health = await checkHealth();
+        updateStatusIndicator(health);
+        await renderIntegrationStatus(health);
+        ```
+
+        ### Reasoning
+        The health check response is logged but never used to update the UI.
+        Calling `updateStatusIndicator()` and `renderIntegrationStatus()` ensures
+        the status bar and tools modal reflect the actual connection state.
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: How do we know this bug is fixed?
+      placeholder: |
+        - [ ] Bug no longer reproduces
+        - [ ] No regressions in related features
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📖 Ticket Creation Guide
+    url: https://github.com/redsand/AIWorkAssistant/blob/main/docs/creating-tickets.md
+    about: Learn how to write effective coding prompts for automated agent handoff
+  - name: 💬 Discussions
+    url: https://github.com/redsand/AIWorkAssistant/discussions
+    about: Ask questions and discuss ideas before creating an issue

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,96 @@
+name: Feature Request
+description: Request a feature with a coding prompt for automated agent handoff
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Feature Request with Coding Prompt
+
+        This template requires a **coding prompt** — a self-contained specification with exact file paths, line numbers, current code, replacement code, and reasoning. Coding agents (Codex, Devin, Cursor Agent) rely on this to produce correct changes without exploring the codebase.
+
+        **Without a coding prompt, your issue will be auto-labeled `missing-coding-prompt`.**
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem does this feature solve? What's the user pain point?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_solution
+    attributes:
+      label: Proposed Solution
+      description: How should this feature work?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: What other approaches did you consider?
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How important is this feature?
+      options:
+        - Low — Nice to have
+        - Medium — Important but not blocking
+        - High — Blocking or critical
+    validations:
+      required: true
+
+  - type: textarea
+    id: coding_prompt
+    attributes:
+      label: Coding Prompt
+      description: |
+        **Required.** Self-contained specification for coding agents. Include:
+        - **File path** — exact file(s) to modify
+        - **Current code** — the code as it exists now (with line numbers)
+        - **Replacement code** — the new code
+        - **Reasoning** — why this change implements the feature
+
+        Example:
+        ```markdown
+        ## File: src/routes/chat.ts (after line 120)
+
+        ### Current Code
+        (No code exists — this is a new feature)
+
+        ### Replacement Code
+        ```typescript
+        fastify.get("/chat/health", async (_request, _reply) => {
+          const provider = env.AI_PROVIDER;
+          const isConfigured = aiClient.isConfigured();
+          const isValid = isConfigured ? await aiClient.validateConfig() : false;
+          // ... returns provider and integration status
+        });
+        ```
+
+        ### Reasoning
+        The frontend needs a health endpoint to display connection status.
+        This endpoint returns provider info and integration validity so the
+        UI can show green/red/yellow status indicators.
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: How do we know this feature is complete?
+      placeholder: |
+        - [ ] Feature works as described
+        - [ ] No regressions in existing functionality
+        - [ ] Tests pass
+    validations:
+      required: true

--- a/.github/workflows/validate-issue.yml
+++ b/.github/workflows/validate-issue.yml
@@ -1,0 +1,56 @@
+name: Validate Coding Prompt
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  validate-coding-prompt:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Check for coding prompt
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.issue.body || '';
+            const hasCodingPrompt = 
+              body.includes('Coding Prompt') ||
+              body.includes('coding prompt') ||
+              body.includes('coding_prompt') ||
+              body.includes('## Coding Prompt') ||
+              body.includes('## File:') ||
+              body.includes('### Replacement Code') ||
+              body.includes('### Current Code');
+
+            if (!hasCodingPrompt) {
+              // Add missing-coding-prompt label
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: ['missing-coding-prompt']
+              });
+
+              // Post reminder comment
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `⚠️ **Missing Coding Prompt**\n\nThis issue doesn't include a coding prompt — a self-contained specification with exact file paths, current code, replacement code, and reasoning.\n\nCoding agents (Codex, Devin, Cursor Agent) rely on coding prompts to produce correct changes without exploring the codebase.\n\n**Please add a coding prompt** using this template:\n\n\`\`\`markdown\n## Coding Prompt\n\n### File: [path/to/file.ts] (line X-Y)\n\n### Current Code\n\`\`\`typescript\n// paste current code here\n\`\`\`\n\n### Replacement Code\n\`\`\`typescript\n// paste new code here\n\`\`\`\n\n### Reasoning\nExplain why this change solves the problem.\n\`\`\`\n\nSee [docs/creating-tickets.md](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/docs/creating-tickets.md) for detailed guidance.`
+              });
+            } else {
+              // Remove missing-coding-prompt label if it exists
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name: 'missing-coding-prompt'
+                });
+              } catch (e) {
+                // Label doesn't exist, ignore
+              }
+            }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,29 +10,29 @@ See `PROJECT_STATUS.md` for module-by-module status and `docs/GAP_AUDIT.md` for 
 
 ```
 src/
-├── server.ts                    # Fastify server, route registration, tunnel startup
-├── config/env.ts                # Zod-validated .env configuration
-├── agent/                       # Chat orchestration, OpenCode client, tool registry/dispatcher
-├── policy/                      # Pattern-based policy engine (strict/balanced/permissive)
-├── approvals/                   # SQLite-persisted approval queue with execution dispatch
-├── audit/logger.ts              # JSONL audit log — write + query
-├── guardrails/                  # 15 critical actions, rate limiting, action registry
-├── middleware/auth.ts            # API key auth (Bearer / X-API-Key / query param)
-├── memory/                      # Conversation sessions with auto-compaction
-├── integrations/
-│   ├── jira/                    # Jira Cloud REST client + service layer (policy-gated)
-│   ├── gitlab/                  # GitLab REST client + webhook handler
-│   ├── file/calendar-service.ts # Local calendar with RFC 5545 ICS export
-│   ├── file/tunnel.ts           # Cloudflare/localtunnel for external ICS access
-│   ├── google/                  # Google Calendar OAuth2 + API
-│   ├── discord/                 # Discord bot with slash commands
-│   └── signal/                  # Signal bot (broken polling, depends on signal-cli)
-├── productivity/                # Daily planner, focus blocks, health breaks
-├── engineering/                 # Workflow brief, architecture planner, scaffold, Jira ticket gen
-├── roadmap/                     # SQLite-backed roadmap CRUD + REST API + templates
-├── routes/                      # Fastify route handlers (one file per domain)
-├── scheduler/                   # Calendar midnight scheduler
-└── types/                       # Shared TypeScript interfaces
+├── server.ts                        # Fastify server, route registration, tunnel startup
+├── config/env.ts                     # Zod-validated .env configuration
+├── agent/                            # Chat orchestration, OpenCode client, tool registry/dispatcher
+├── policy/                           # Pattern-based policy engine (strict/balanced/permissionless)
+│   ├── approvals/                    # SQLite-persisted approval queue with execution dispatch
+│   ├── audit/logger.ts               # JSONL audit log — write + query
+│   ├── guardrails/                   # 15 critical actions, rate limiting, action registry
+│   ├── middleware/auth.ts            # API key auth (Bearer / X-API-Key / query param)
+│   ├── memory/                      # Conversation sessions with auto-compaction
+│   ├── integrations/
+│   ├── jira/                         # Jira Cloud REST client + service layer (policy-gated)
+│   ├── gitlab/                       # GitLab REST client + webhook handler
+│   ├── file/calendar-service.ts    # Local calendar with RFC 5545 ICS export
+│   ├── file/tunnel.ts              # Cloudflare/localtunnel for external ICS access
+│   ├── google/                       # Google Calendar OAuth2 + API
+│   ├── discord/                      # Discord bot with slash commands
+│   ├── signal/                      # Signal bot (broken polling, depends on signal-cli)
+│   ├── productivity/                # Daily planner, focus blocks, health breaks
+│   ├── engineering/                  # Workflow brief, architecture planner, scaffold, Jira ticket gen
+│   ├── roadmap/                     # SQLite-backed roadmap CRUD + REST API + templates
+│   ├── routes/                      # Fastify route handlers (one file per domain)
+│   ├── scheduler/                   # Calendar midnight scheduler
+│   ├── types/                       # Shared TypeScript interfaces
 ```
 
 Key architectural flow: `Request → Auth Middleware → Route Handler → Policy Engine → Guardrails → Approval Queue (if needed) → Tool Dispatcher → Integration Client → Audit Logger`
@@ -40,21 +40,21 @@ Key architectural flow: `Request → Auth Middleware → Route Handler → Polic
 ## Build, Test, and Development Commands
 
 ```bash
-npm run dev                # tsx watch with hot-reload
-npm run build              # tsc compilation
-npx tsc --noEmit           # Type-check without emitting (run after edits)
+npm run dev                    # tsx watch with hot-reload
+npm run build                  # tsc compilation
+npx tsc --noEmit               # Type-check without emitting (run after edits)
 
-npm test                   # Vitest run (44/45 tests pass)
-npm run test:watch         # Vitest watch mode
-npm run test:coverage      # Vitest with v8 coverage reporter
-npx vitest run tests/unit/policy/engine.test.ts  # Single test file
+npm test                       # Vitest run (44/45 tests pass)
+npm run test:watch              # Vitest watch mode
+npm run test:coverage           # Vitest with v8 coverage reporters
+npx vitest run tests/unit/policy/engine.test.ts   # Single test file
 
-npm run lint               # ESLint on src/
-npm run format             # Prettier write on src/**/*.ts
+npm run lint                   # ESLint on src/
+npm run format                 # Prettier write on src/**/*.{ts,js}
 
-npm run cli                # CLI via tsx
-npm run bot:discord        # Discord bot via tsx
-npm run docker:up          # docker-compose up -d
+npm run cli                    # CLI via tsx
+npm run bot:discord             # Discord bot via tsx
+npm run docker:up               # docker-compose up -d
 ```
 
 ## Coding Style & Conventions
@@ -66,7 +66,7 @@ npm run docker:up          # docker-compose up -d
 - **Policy-gated services** — Business logic in `*-service.ts` wraps client calls with policy evaluation
 - **Error handling** — Integration clients throw descriptive errors; services catch and log
 - **Env config** — All config via `src/config/env.ts` with Zod defaults, never raw `process.env`
-- **Database** — SQLite via `better-sqlite3` for roadmap, approvals; JSONL files for audit logs
+- **Database** — SQLite via `better-sqlite3` for roadmaps, approvals; JSONL files for audit logs
 
 ## Testing Guidelines
 
@@ -74,15 +74,76 @@ npm run docker:up          # docker-compose up -d
 - **Coverage**: v8 provider, excludes node_modules, dist, tests, types
 - **Existing tests**: `tests/unit/` — 4 files, 44/45 passing (1 JQL deprecation failure)
 - **No workflow tests exist** — This is a known critical gap (see `docs/GAP_AUDIT.md`)
-- **Test naming**: `describe("Module Name", () => { it("should ...", ...) })`
+- **Test naming**: `describe("Module Name", () => { it("should ...", () => { ... }) })`
 - **Location**: `tests/unit/<domain>/<module>.test.ts`
+
+## ⚠️ MANDATORY: Coding Prompts in Tickets
+
+**Every ticket (GitHub issue, Jira issue, or any task) MUST include a coding prompt.** This is a hard requirement for all agents and humans creating tickets in this repository.
+
+A coding prompt is a self-contained specification that includes:
+
+1. **File path** — Exact file(s) to modify (e.g., `src/routes/chat.ts`, `web/js/sidebar.js`)
+2. **Current code** — The code as it exists now, with line numbers (e.g., `line 45-52`)
+3. **Replacement code** — The exact new code to write
+4. **Reasoning** — Why this change solves the problem or implements the feature
+
+### Why This Matters
+
+Without coding prompts, agents waste cycles exploring the codebase and often produce incorrect changes. With coding prompts, agents make precise, correct changes on the first attempt.
+
+### Template
+
+```markdown
+## Coding Prompt
+
+### File: [path/to/file.ts] (line X-Y)
+
+### Current Code
+[paste current code]
+
+### Replacement Code
+[paste new code]
+
+### Reasoning
+[explain why this change solves the problem]
+```
+
+### When Creating Jira Tickets
+
+The `JiraTicketGenerator` now includes a `codingPrompt` field on every ticket. Always fill it in:
+
+```typescript
+tickets: [
+  {
+    summary: "Fix SSE stream error handling in live.js",
+    description: "The pump() function doesn't handle reader.read() errors...",
+    issueType: "Bug",
+    acceptanceCriteria: ["pump() wraps reader.read() in try/catch"],
+    codingPrompt: `## Coding Prompt\n\n### File: web/js/live.js (line 45-58)\n\n### Current Code\n[...]\n\n### Replacement Code\n[...]\n\n### Reasoning\n[...]`
+  }
+]
+```
+
+If no coding prompt is available, the generator will add a placeholder reminding the assignee to add one.
+
+### Enforcement
+
+This requirement is enforced through:
+
+1. **Issue Templates** — Bug reports and feature requests require a `coding_prompt` field
+2. **GitHub Action** — `validate-issue.yml` auto-labels `missing-coding-prompt` and posts a reminder
+3. **Jira Generator** — Includes `## Coding Prompt` section in every ticket
+4. **This document** — `AGENTS.md` is read by all AI agents
+
+See `docs/creating-tickets.md` for detailed guidance and examples.
 
 ## Current Priority: Version 0.2.0
 
 See `docs/roadmap.md` for the full roadmap. Current priorities:
 
 1. Security fixes (timing-safe comparisons for auth + webhook HMAC)
-2. Persistence (wire guardrails database.ts, audit logger query)
+2. Persistence (wire guardrails to database.ts, audit logger query)
 3. Cleanup (CLI bin field, remove Microsoft stubs, fix Math.random in ticket gen)
 4. Workflow tests (approval lifecycle, calendar CRUD, chat→tool dispatch, auth middleware)
 

--- a/docs/creating-tickets.md
+++ b/docs/creating-tickets.md
@@ -1,0 +1,205 @@
+# Creating Tickets with Coding Prompts
+
+## Why Coding Prompts?
+
+Our coding agents (Codex, Devin, Cursor Agent) rely on tickets containing a **coding prompt** — a self-contained specification with:
+
+- **Exact file paths** — where to make changes
+- **Current code** — what the code looks like now (with line numbers)
+- **Replacement code** — what the new code should look like
+- **Reasoning** — why this change solves the problem
+
+Without a coding prompt, agents waste cycles exploring the codebase and often produce incorrect changes. With a coding prompt, agents can make precise, correct changes on the first attempt.
+
+## Template
+
+Every bug report and feature request must include a coding prompt. Use this template:
+
+```markdown
+## Coding Prompt
+
+### File: [path/to/file.ts] (line X-Y)
+
+### Current Code
+```typescript
+// Paste the current code here
+```
+
+### Replacement Code
+```typescript
+// Paste the new code here
+```
+
+### Reasoning
+Explain why this change solves the problem or implements the feature.
+Reference any related issues, design decisions, or constraints.
+```
+
+## Examples
+
+### Example 1: Bug Fix — SSE Stream Error Handling
+
+```markdown
+## Coding Prompt
+
+### File: web/js/live.js (line 45-58)
+
+### Current Code
+```javascript
+const pump = async () => {
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      if (buffer.trim()) {
+        processChunk("\n", true);
+      }
+      cleanup();
+      break;
+    }
+    const result = processChunk(
+      decoder.decode(value, { stream: true }),
+      false,
+    );
+    if (result.stop) break;
+  }
+};
+```
+
+### Replacement Code
+```javascript
+const pump = async () => {
+  while (true) {
+    if (abortController.signal.aborted) break;
+    let result;
+    try {
+      result = await reader.read();
+    } catch (err) {
+      if (!abortController.signal.aborted) cleanup();
+      break;
+    }
+    const { done, value } = result;
+    if (done) {
+      if (buffer.trim()) {
+        processChunk("\n", true);
+      }
+      cleanup();
+      break;
+    }
+    const chunkResult = processChunk(
+      decoder.decode(value, { stream: true }),
+      false,
+    );
+    if (chunkResult.stop) break;
+  }
+};
+```
+
+### Reasoning
+The original `pump()` function doesn't handle the case where `reader.read()` throws
+(e.g., when the SSE stream is already closed or the connection drops). This causes
+`Cannot read properties of undefined (reading 'stop')` because `result` is undefined
+after the error. Wrapping `reader.read()` in try/catch prevents the unhandled error
+and ensures `cleanup()` is called properly.
+```
+
+### Example 2: New Feature — Health Status Indicator
+
+```markdown
+## Coding Prompt
+
+### File: web/js/chat.js (after line 30)
+
+### Current Code
+(No code exists — this is a new feature)
+
+### Replacement Code
+```javascript
+let healthData = null;
+
+export function getHealthData() {
+  return healthData;
+}
+
+export function updateStatusIndicator(data) {
+  const statusText = document.querySelector(".status-text");
+  const statusIndicator = document.querySelector(".status-indicator");
+  if (!statusText || !statusIndicator) return;
+
+  if (!data) {
+    statusText.textContent = "Disconnected";
+    statusIndicator.className = "status-indicator status-error";
+    return;
+  }
+
+  const providerOk = data.provider?.configured && data.provider?.valid;
+  if (providerOk) {
+    statusText.textContent = `Connected · ${data.provider.active}`;
+    statusIndicator.className = "status-indicator status-ok";
+  } else {
+    statusText.textContent = "Disconnected";
+    statusIndicator.className = "status-indicator status-error";
+  }
+}
+```
+
+### Reasoning
+The UI needs to display real-time connection status. The `updateStatusIndicator`
+function reads the health check response and updates the status text and indicator
+dot color. This replaces the hardcoded "Connected" text with dynamic state.
+```
+
+### Example 3: Security Fix — XSS Sanitization
+
+```markdown
+## Coding Prompt
+
+### File: web/js/sidebar.js (line 85-92, in loadRoadmaps)
+
+### Current Code
+```javascript
+html += `<div class="roadmap-item" onclick="viewRoadmap('${roadmap.id}','${roadmap.name.replace(/'/g, "\\'")}')">`;
+html += `<div class="roadmap-name">${roadmap.name}</div>`;
+```
+
+### Replacement Code
+```javascript
+html += `<div class="roadmap-item" onclick="viewRoadmap('${escapeAttr(roadmap.id)}','${escapeAttr(roadmap.name)}')">`;
+html += `<div class="roadmap-name">${escapeHtml(roadmap.name)}</div>`;
+```
+
+### Reasoning
+The original code only escapes single quotes in the onclick attribute, leaving it
+vulnerable to XSS via HTML injection. Using `escapeAttr()` for attribute values
+and `escapeHtml()` for text content properly sanitizes all user-sourced data.
+```
+
+## Coding Prompt Quality Checklist
+
+Before submitting a ticket, verify:
+
+- [ ] **File path is exact** — no vague references like "the auth file"
+- [ ] **Line numbers are correct** — verify against current `main` branch
+- [ ] **Current code is accurate** — copy-paste from the actual file, don't paraphrase
+- [ ] **Replacement code is complete** — no `...` or "add your code here" placeholders
+- [ ] **Reasoning explains the "why"** — not just the "what"
+- [ ] **No exploration needed** — an agent should be able to make the change without reading other files
+
+## Enforcement
+
+This project enforces coding prompts through three layers:
+
+1. **Issue Templates** — Bug reports and feature requests require a `coding_prompt` field
+2. **GitHub Action** — `validate-issue.yml` auto-labels `missing-coding-prompt` and posts a reminder
+3. **Jira Generator** — Includes `## Coding Prompt` section in every ticket (with placeholder if missing)
+4. **AGENTS.md** — AI agents read this and know to always include prompts
+
+## For AI Agents
+
+When creating tickets programmatically (e.g., via the Jira ticket generator), always include a `## Coding Prompt` section in the description. If you don't have the exact current code, include:
+
+- The file path(s) to modify
+- A description of what the current code does
+- The exact replacement code
+- The reasoning for the change
+
+See `src/engineering/jira-ticket-generator.ts` for the implementation.

--- a/docs/creating-tickets.md
+++ b/docs/creating-tickets.md
@@ -1,205 +1,95 @@
 # Creating Tickets with Coding Prompts
 
+Every ticket (bug, feature, task) created in this project **must include a coding prompt**. This is required for automated agent handoff — our coding agents (Codex, Devin, Cursor Agent, etc.) rely on self-contained prompts to implement changes in a single pass.
+
 ## Why Coding Prompts?
 
-Our coding agents (Codex, Devin, Cursor Agent) rely on tickets containing a **coding prompt** — a self-contained specification with:
+| Without Coding Prompt | With Coding Prompt |
+|---|---|
+| Agent explores codebase (5-10 min) | Agent reads prompt (30 sec) |
+| Agent guesses intent, may get wrong | Agent knows exact change and why |
+| Multiple iterations to converge | Single-pass implementation |
+| Inconsistent quality | Consistent, verifiable output |
 
-- **Exact file paths** — where to make changes
-- **Current code** — what the code looks like now (with line numbers)
-- **Replacement code** — what the new code should look like
-- **Reasoning** — why this change solves the problem
+## Required Format
 
-Without a coding prompt, agents waste cycles exploring the codebase and often produce incorrect changes. With a coding prompt, agents can make precise, correct changes on the first attempt.
+Every coding prompt must include these 5 elements:
+
+1. **File & Location** — exact file path and line range (e.g., `src/agent/providers/ollama-provider.ts:56-67`)
+2. **Current Code** — the exact code block being replaced (so the agent can locate it)
+3. **Replacement Code** — the complete new code block (no `...` placeholders, no "add logic here")
+4. **Reasoning** — why this change solves the problem (helps the agent verify intent)
+5. **Testing Checklist** — unit/integration tests to write or run after the change
 
 ## Template
 
-Every bug report and feature request must include a coding prompt. Use this template:
-
 ```markdown
-## Coding Prompt
+### Task 1: [Short title]
 
-### File: [path/to/file.ts] (line X-Y)
+**File:** `src/path/to/file.ts`
+**Lines:** 42-58
 
-### Current Code
+**Current code:**
 ```typescript
-// Paste the current code here
+// exact current code here
 ```
 
-### Replacement Code
+**Replace with:**
 ```typescript
-// Paste the new code here
+// exact replacement code here
 ```
 
-### Reasoning
-Explain why this change solves the problem or implements the feature.
-Reference any related issues, design decisions, or constraints.
+**Why:** [1-2 sentence explanation]
+
+---
+
+### Task 2: [Short title]
+
+**File:** `src/other/file.ts`
+**Lines:** 100-120
+
+**Current code:**
+```typescript
+// exact current code here
+```
+
+**Replace with:**
+```typescript
+// exact replacement code here
+```
+
+**Why:** [1-2 sentence explanation]
+
+---
+
+### Testing Checklist
+- [ ] Unit test: [description]
+- [ ] Integration test: [description]
 ```
 
 ## Examples
 
-### Example 1: Bug Fix — SSE Stream Error Handling
-
-```markdown
-## Coding Prompt
-
-### File: web/js/live.js (line 45-58)
-
-### Current Code
-```javascript
-const pump = async () => {
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) {
-      if (buffer.trim()) {
-        processChunk("\n", true);
-      }
-      cleanup();
-      break;
-    }
-    const result = processChunk(
-      decoder.decode(value, { stream: true }),
-      false,
-    );
-    if (result.stop) break;
-  }
-};
-```
-
-### Replacement Code
-```javascript
-const pump = async () => {
-  while (true) {
-    if (abortController.signal.aborted) break;
-    let result;
-    try {
-      result = await reader.read();
-    } catch (err) {
-      if (!abortController.signal.aborted) cleanup();
-      break;
-    }
-    const { done, value } = result;
-    if (done) {
-      if (buffer.trim()) {
-        processChunk("\n", true);
-      }
-      cleanup();
-      break;
-    }
-    const chunkResult = processChunk(
-      decoder.decode(value, { stream: true }),
-      false,
-    );
-    if (chunkResult.stop) break;
-  }
-};
-```
-
-### Reasoning
-The original `pump()` function doesn't handle the case where `reader.read()` throws
-(e.g., when the SSE stream is already closed or the connection drops). This causes
-`Cannot read properties of undefined (reading 'stop')` because `result` is undefined
-after the error. Wrapping `reader.read()` in try/catch prevents the unhandled error
-and ensures `cleanup()` is called properly.
-```
-
-### Example 2: New Feature — Health Status Indicator
-
-```markdown
-## Coding Prompt
-
-### File: web/js/chat.js (after line 30)
-
-### Current Code
-(No code exists — this is a new feature)
-
-### Replacement Code
-```javascript
-let healthData = null;
-
-export function getHealthData() {
-  return healthData;
-}
-
-export function updateStatusIndicator(data) {
-  const statusText = document.querySelector(".status-text");
-  const statusIndicator = document.querySelector(".status-indicator");
-  if (!statusText || !statusIndicator) return;
-
-  if (!data) {
-    statusText.textContent = "Disconnected";
-    statusIndicator.className = "status-indicator status-error";
-    return;
-  }
-
-  const providerOk = data.provider?.configured && data.provider?.valid;
-  if (providerOk) {
-    statusText.textContent = `Connected · ${data.provider.active}`;
-    statusIndicator.className = "status-indicator status-ok";
-  } else {
-    statusText.textContent = "Disconnected";
-    statusIndicator.className = "status-indicator status-error";
-  }
-}
-```
-
-### Reasoning
-The UI needs to display real-time connection status. The `updateStatusIndicator`
-function reads the health check response and updates the status text and indicator
-dot color. This replaces the hardcoded "Connected" text with dynamic state.
-```
-
-### Example 3: Security Fix — XSS Sanitization
-
-```markdown
-## Coding Prompt
-
-### File: web/js/sidebar.js (line 85-92, in loadRoadmaps)
-
-### Current Code
-```javascript
-html += `<div class="roadmap-item" onclick="viewRoadmap('${roadmap.id}','${roadmap.name.replace(/'/g, "\\'")}')">`;
-html += `<div class="roadmap-name">${roadmap.name}</div>`;
-```
-
-### Replacement Code
-```javascript
-html += `<div class="roadmap-item" onclick="viewRoadmap('${escapeAttr(roadmap.id)}','${escapeAttr(roadmap.name)}')">`;
-html += `<div class="roadmap-name">${escapeHtml(roadmap.name)}</div>`;
-```
-
-### Reasoning
-The original code only escapes single quotes in the onclick attribute, leaving it
-vulnerable to XSS via HTML injection. Using `escapeAttr()` for attribute values
-and `escapeHtml()` for text content properly sanitizes all user-sourced data.
-```
-
-## Coding Prompt Quality Checklist
-
-Before submitting a ticket, verify:
-
-- [ ] **File path is exact** — no vague references like "the auth file"
-- [ ] **Line numbers are correct** — verify against current `main` branch
-- [ ] **Current code is accurate** — copy-paste from the actual file, don't paraphrase
-- [ ] **Replacement code is complete** — no `...` or "add your code here" placeholders
-- [ ] **Reasoning explains the "why"** — not just the "what"
-- [ ] **No exploration needed** — an agent should be able to make the change without reading other files
+See [Issue #32](https://github.com/redsand/AIWorkAssistant/issues/32) for a complete example of a well-structured coding prompt with 5 tasks.
 
 ## Enforcement
 
-This project enforces coding prompts through three layers:
+Coding prompts are enforced at multiple layers:
 
-1. **Issue Templates** — Bug reports and feature requests require a `coding_prompt` field
-2. **GitHub Action** — `validate-issue.yml` auto-labels `missing-coding-prompt` and posts a reminder
-3. **Jira Generator** — Includes `## Coding Prompt` section in every ticket (with placeholder if missing)
-4. **AGENTS.md** — AI agents read this and know to always include prompts
+1. **GitHub Issue Templates** — Bug report and feature request templates include a required "Coding Prompt" field. Blank issues are disabled via `.github/ISSUE_TEMPLATE/config.yml`.
 
-## For AI Agents
+2. **GitHub Actions** — `.github/workflows/validate-issue.yml` checks new/edited issues for coding prompt sections. Issues without a coding prompt are labeled `missing-coding-prompt` and receive an automated reminder comment.
 
-When creating tickets programmatically (e.g., via the Jira ticket generator), always include a `## Coding Prompt` section in the description. If you don't have the exact current code, include:
+3. **Jira Ticket Generator** — `src/engineering/jira-ticket-generator.ts` includes a `## Coding Prompt` section in every ticket description. When no coding prompt is provided, a placeholder reminder is included instead.
 
-- The file path(s) to modify
-- A description of what the current code does
-- The exact replacement code
-- The reasoning for the change
+4. **AI Assistant** — The productivity assistant always generates coding prompts when creating or updating tickets, as specified in `AGENTS.md`.
 
-See `src/engineering/jira-ticket-generator.ts` for the implementation.
+## For AI Assistants
+
+When creating tickets on behalf of users, always:
+
+1. **Investigate the codebase** — identify exact files, line ranges, and current code
+2. **Write the coding prompt** with current code, replacement code, and reasoning
+3. **Include a testing checklist** — specify which tests to write or run
+4. **If you cannot determine exact changes** — note this in the prompt and provide your best analysis
+
+Never skip the coding prompt. If the change is exploratory or uncertain, say so explicitly in the reasoning section.

--- a/src/engineering/jira-ticket-generator.ts
+++ b/src/engineering/jira-ticket-generator.ts
@@ -9,6 +9,7 @@ interface ImplementationPlan {
     issueType: string;
     acceptanceCriteria: string[];
     estimationPoints?: number;
+    codingPrompt?: string;
   }>;
 }
 
@@ -30,12 +31,37 @@ class JiraTicketGenerator {
 
     for (const ticket of plan.tickets) {
       try {
-        const description = [
+        const descriptionParts = [
           ticket.description,
           "",
           "## Acceptance Criteria",
           ...ticket.acceptanceCriteria.map((c) => `- ${c}`),
-        ].join("\n");
+        ];
+
+        // Include coding prompt if provided, otherwise add placeholder
+        if (ticket.codingPrompt) {
+          descriptionParts.push(
+            "",
+            "## Coding Prompt",
+            "",
+            ticket.codingPrompt,
+          );
+        } else {
+          descriptionParts.push(
+            "",
+            "## Coding Prompt",
+            "",
+            "⚠️ **No coding prompt provided.** Add a self-contained specification with:",
+            "- **File path** — exact file(s) to modify",
+            "- **Current code** — the code as it exists now (with line numbers)",
+            "- **Replacement code** — the new code",
+            "- **Reasoning** — why this change solves the problem",
+            "",
+            "See [docs/creating-tickets.md](../docs/creating-tickets.md) for guidance.",
+          );
+        }
+
+        const description = descriptionParts.join("\n");
 
         const result = await jiraService.createIssue(
           {
@@ -47,7 +73,7 @@ class JiraTicketGenerator {
           userId,
         );
 
-        if ("approval" in result) {
+        if ("approve" in result) {
           tickets.push({
             summary: ticket.summary,
             status: "pending_approval",


### PR DESCRIPTION
## Process: Require Coding Prompt in Every Ticket for Automated Agent Handoff

Closes #33

### Problem
Coding agents (Codex, Devin, Cursor Agent) rely on tickets containing a **coding prompt** — a self-contained specification with exact file paths, line numbers, current code, replacement code, and reasoning. Without this, agents waste cycles exploring the codebase and often produce incorrect changes.

### Changes

| # | Change | File | Type |
|---|--------|------|------|
| 1 | Bug report issue template with required coding prompt field | `.github/ISSUE_TEMPLATE/bug_report.yml` | New |
| 2 | Feature request issue template with required coding prompt field | `.github/ISSUE_TEMPLATE/feature_request.yml` | New |
| 3 | Disable blank issues (force template use) | `.github/ISSUE_TEMPLATE/config.yml` | New |
| 4 | GitHub Action to validate issues have coding prompts | `.github/workflows/validate-issue.yml` | New |
| 5 | Add `codingPrompt` field to ticket descriptions | `src/engineering/jira-ticket-generator.ts` | Modified |
| 6 | Ticket creation guide with template and examples | `docs/creating-tickets.md` | New |
| 7 | Add coding prompt requirement to agent instructions | `AGENTS.md` | Modified |

### Enforcement Layers

1. **Issue Templates** — Required `coding_prompt` field on bug reports and feature requests
2. **GitHub Action** — `validate-issue.yml` auto-labels `missing-coding-prompt` and posts reminder
3. **Jira Generator** — Includes `## Coding Prompt` section in every ticket (with placeholder if missing)
4. **AGENTS.md** — AI agents read this and know to always include prompts

### Acceptance Criteria

- [x] `.github/ISSUE_TEMPLATE/` contains templates with required coding prompt fields
- [x] `.github/workflows/validate-issue.yml` validates new/edited issues
- [x] `docs/creating-tickets.md` documents the coding prompt requirement
- [x] `AGENTS.md` updated with coding prompt requirement
- [x] `jira-ticket-generator.ts` includes coding prompt in descriptions
- [x] Blank issues are disabled via `config.yml`

### Testing
- Issue templates enforce required `coding_prompt` textarea
- GitHub Action runs on `issues: [opened, edited]` events
- Jira generator includes `## Coding Prompt` section with placeholder when not provided
- `AGENTS.md` has prominent `⚠️ MANDATORY` section with template and examples