### PR TITLE
[AI] [ClaimKit #7] Create A/B comparison eval runner (RAG vs ClaimKit)

### DIFF
--- a/src/eval/comparison/claimkit-comparison.ts
+++ b/src/eval/comparison/claimkit-comparison.ts
@@ -1,0 +1,145 @@
+import { assembleContextPacket } from "../../context-engine/context-packet";
+import { claimKitAdapter } from "../../context-engine/adapters/claimkit-adapter";
+import type { ComparisonRunResult, ComparisonCase } from "./reportTypes";
+import type { ComparisonEvalCategory } from "../types";
+import { evaluateThresholds, DEFAULT_THRESHOLDS } from "./thresholds";
+
+export interface ComparisonConfig {
+  queries: string[];
+  categories: ComparisonEvalCategory[];
+  thresholds?: typeof DEFAULT_THRESHOLDS;
+}
+
+export async function runClaimKitComparison(
+  config: ComparisonConfig,
+): Promise<ComparisonRunResult> {
+  const ckAvailable = await claimKitAdapter.initialize();
+  const cases: ComparisonCase[] = [];
+
+  for (const query of config.queries) {
+    // Run existing RAG pipeline
+    const ragStart = Date.now();
+    const ragPacket = await assembleContextPacket({
+      mode: "engineering",
+      query,
+      sessionMessages: [],
+      sessionId: "eval",
+      includeMemory: false,
+      toolInventory: "",
+      providerMaxTokens: 8192,
+      toolTokens: 0,
+      userId: "eval",
+    });
+    const ragMs = Date.now() - ragStart;
+
+    // Run ClaimKit pipeline
+    let ckResult = null;
+    let ckMs = 0;
+    if (ckAvailable) {
+      const ckStart = Date.now();
+      try {
+        ckResult = await claimKitAdapter.query(query);
+        ckMs = Date.now() - ckStart;
+      } catch (err) {
+        console.warn(`[ClaimKit Comparison] Query failed: ${query}`, err);
+      }
+    }
+
+    // Determine winner per category
+    const overallWinner = determineOverallWinner(ckResult);
+
+    cases.push({
+      query,
+      category: categorizeQuery(query, config.categories),
+      overallWinner,
+      rag: {
+        contextTokens: ragPacket.totalTokens,
+        sections: ragPacket.sections.length,
+        processingTimeMs: ragMs,
+      },
+      claimkit: ckResult
+        ? {
+            confidence: ckResult.confidence,
+            answerability: ckResult.answerability,
+            claimCount: ckResult.metadata.claimCount,
+            processingTimeMs: ckMs,
+            contradictions: ckResult.contradictions.length,
+          }
+        : null,
+    });
+  }
+
+  // Aggregate results
+  const totalCases = cases.length;
+  const claimKitWins = cases.filter((c) => c.overallWinner === "claimkit").length;
+  const ragWins = cases.filter((c) => c.overallWinner === "rag").length;
+  const ties = cases.filter((c) => c.overallWinner === "tie").length;
+
+  const result: ComparisonRunResult = {
+    totalCases,
+    cases,
+    aggregate: {
+      wins: { claimkit: claimKitWins, rag: ragWins, tie: ties },
+      claimkit: {
+        mean: aggregateClaimKitStats(cases),
+      },
+      rag: {
+        mean: aggregateRagStats(cases),
+      },
+    },
+  };
+
+  result.thresholdEvaluation = evaluateThresholds(
+    result,
+    config.thresholds ?? DEFAULT_THRESHOLDS,
+  );
+
+  return result;
+}
+
+function determineOverallWinner(
+  ck: Awaited<ReturnType<typeof claimKitAdapter.query>> | null,
+): "rag" | "claimkit" | "tie" {
+  if (!ck) return "rag";
+  // ClaimKit wins if it has confidence > 0.5 AND answerability is "answerable"
+  if (ck.confidence > 0.5 && ck.answerability === "answerable") return "claimkit";
+  // RAG wins if ClaimKit has low confidence or can't answer
+  if (ck.confidence < 0.3 || ck.answerability === "not_answerable") return "rag";
+  return "tie";
+}
+
+function categorizeQuery(
+  query: string,
+  categories: ComparisonEvalCategory[],
+): ComparisonEvalCategory {
+  const lower = query.toLowerCase();
+  const determined = ((): ComparisonEvalCategory => {
+    if (lower.includes("code") || lower.includes("file") || lower.includes("function")) return "code_retrieval";
+    if (lower.includes("who") || lower.includes("person") || lower.includes("owner")) return "entity_linking";
+    if (lower.includes("when") || lower.includes("date") || lower.includes("last")) return "staleness";
+    if (lower.includes("cite") || lower.includes("source") || lower.includes("reference")) return "citation_laundering";
+    return "direct_fact";
+  })();
+  return categories.includes(determined) ? determined : (categories[0] ?? determined);
+}
+
+function aggregateClaimKitStats(cases: ComparisonCase[]) {
+  const withCk = cases.filter((c) => c.claimkit !== null);
+  if (withCk.length === 0) return { confidence: 0, answerabilityRate: 0, avgClaims: 0, avgTimeMs: 0 };
+  return {
+    confidence: withCk.reduce((s, c) => s + (c.claimkit?.confidence ?? 0), 0) / withCk.length,
+    answerabilityRate:
+      withCk.filter((c) => c.claimkit?.answerability === "answerable").length / withCk.length,
+    avgClaims: withCk.reduce((s, c) => s + (c.claimkit?.claimCount ?? 0), 0) / withCk.length,
+    avgTimeMs: withCk.reduce((s, c) => s + (c.claimkit?.processingTimeMs ?? 0), 0) / withCk.length,
+  };
+}
+
+function aggregateRagStats(cases: ComparisonCase[]) {
+  if (cases.length === 0) return { avgTokens: 0, avgSections: 0, avgTimeMs: 0 };
+  return {
+    avgTokens: cases.reduce((s, c) => s + c.rag.contextTokens, 0) / cases.length,
+    avgSections: cases.reduce((s, c) => s + c.rag.sections, 0) / cases.length,
+    avgTimeMs: cases.reduce((s, c) => s + c.rag.processingTimeMs, 0) / cases.length,
+  };
+}

--- a/src/eval/comparison/reportTypes.ts
+++ b/src/eval/comparison/reportTypes.ts
@@ -1,0 +1,52 @@
+import type { ComparisonEvalCategory } from "../types";
+
+export interface ThresholdEvaluation {
+  passed: boolean;
+  failures: string[];
+}
+
+export interface ComparisonCaseRag {
+  contextTokens: number;
+  sections: number;
+  processingTimeMs: number;
+}
+
+export interface ComparisonCaseClaimKit {
+  confidence: number;
+  answerability: "answerable" | "partially_answerable" | "not_answerable";
+  claimCount: number;
+  processingTimeMs: number;
+  contradictions: number;
+}
+
+export interface ComparisonCase {
+  query: string;
+  category: ComparisonEvalCategory;
+  overallWinner: "rag" | "claimkit" | "tie";
+  rag: ComparisonCaseRag;
+  claimkit: ComparisonCaseClaimKit | null;
+}
+
+export interface ComparisonRunResult {
+  totalCases: number;
+  cases: ComparisonCase[];
+  aggregate: {
+    wins: { claimkit: number; rag: number; tie: number };
+    claimkit: {
+      mean: {
+        confidence: number;
+        answerabilityRate: number;
+        avgClaims: number;
+        avgTimeMs: number;
+      };
+    };
+    rag: {
+      mean: {
+        avgTokens: number;
+        avgSections: number;
+        avgTimeMs: number;
+      };
+    };
+  };
+  thresholdEvaluation?: ThresholdEvaluation;
+}

--- a/src/eval/comparison/thresholds.ts
+++ b/src/eval/comparison/thresholds.ts
@@ -1,0 +1,56 @@
+import type { ComparisonRunResult, ThresholdEvaluation } from "./reportTypes";
+
+export interface ThresholdConfig {
+  minClaimKitWinRate: number;
+  minClaimKitConfidence: number;
+  minAnswerabilityRate: number;
+  maxAvgProcessingTimeMs: number;
+}
+
+export const DEFAULT_THRESHOLDS: ThresholdConfig = {
+  minClaimKitWinRate: 0.5,
+  minClaimKitConfidence: 0.6,
+  minAnswerabilityRate: 0.7,
+  maxAvgProcessingTimeMs: 5000,
+};
+
+export function evaluateThresholds(
+  result: ComparisonRunResult,
+  thresholds: ThresholdConfig = DEFAULT_THRESHOLDS,
+): ThresholdEvaluation {
+  const failures: string[] = [];
+
+  const winRate =
+    result.totalCases > 0
+      ? result.aggregate.wins.claimkit / result.totalCases
+      : 0;
+
+  if (winRate < thresholds.minClaimKitWinRate) {
+    failures.push(
+      `ClaimKit win rate ${(winRate * 100).toFixed(1)}% below threshold ${(thresholds.minClaimKitWinRate * 100).toFixed(1)}%`,
+    );
+  }
+
+  const { confidence, answerabilityRate, avgTimeMs } =
+    result.aggregate.claimkit.mean;
+
+  if (confidence < thresholds.minClaimKitConfidence) {
+    failures.push(
+      `Mean confidence ${confidence.toFixed(2)} below threshold ${thresholds.minClaimKitConfidence}`,
+    );
+  }
+
+  if (answerabilityRate < thresholds.minAnswerabilityRate) {
+    failures.push(
+      `Answerability rate ${(answerabilityRate * 100).toFixed(1)}% below threshold ${(thresholds.minAnswerabilityRate * 100).toFixed(1)}%`,
+    );
+  }
+
+  if (avgTimeMs > thresholds.maxAvgProcessingTimeMs) {
+    failures.push(
+      `Mean processing time ${avgTimeMs.toFixed(0)}ms exceeds threshold ${thresholds.maxAvgProcessingTimeMs}ms`,
+    );
+  }
+
+  return { passed: failures.length === 0, failures };
+}

--- a/src/eval/types.ts
+++ b/src/eval/types.ts
@@ -1,0 +1,6 @@
+export type ComparisonEvalCategory =
+  | "code_retrieval"
+  | "entity_linking"
+  | "staleness"
+  | "citation_laundering"
+  | "direct_fact";

--- a/tests/unit/eval/comparison/claimkit-comparison.test.ts
+++ b/tests/unit/eval/comparison/claimkit-comparison.test.ts
@@ -1,0 +1,376 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../../src/context-engine/context-packet', () => ({
+  assembleContextPacket: vi.fn(),
+}));
+
+vi.mock('../../../../src/context-engine/adapters/claimkit-adapter', () => ({
+  claimKitAdapter: {
+    initialize: vi.fn(),
+    query: vi.fn(),
+  },
+}));
+
+import { runClaimKitComparison } from '../../../../src/eval/comparison/claimkit-comparison';
+import { assembleContextPacket } from '../../../../src/context-engine/context-packet';
+import { claimKitAdapter } from '../../../../src/context-engine/adapters/claimkit-adapter';
+
+function makeRagPacket(overrides: Record<string, unknown> = {}) {
+  return {
+    totalTokens: 1000,
+    sections: [{ name: 'system' }, { name: 'documents' }],
+    messages: [],
+    budgetBreakdown: [],
+    diagnostics: {
+      mode: 'engineering',
+      originalMessageCount: 0,
+      finalMessageCount: 1,
+      documentsRetrieved: 3,
+      documentsCompressed: 2,
+      compressionRatio: 1.5,
+      budgetUtilization: {},
+      createdAt: new Date(),
+    },
+    ...overrides,
+  };
+}
+
+function makeCkResult(overrides: Record<string, unknown> = {}) {
+  return {
+    answer: 'The answer',
+    citations: [],
+    confidence: 0.8,
+    contradictions: [],
+    missingEvidence: [],
+    answerability: 'answerable' as const,
+    metadata: {
+      sourceIds: ['s1'],
+      claimCount: 5,
+      processingTimeMs: 120,
+      retrievalScore: 0.9,
+    },
+    ...overrides,
+  };
+}
+
+const ALL_CATEGORIES = [
+  'code_retrieval',
+  'entity_linking',
+  'staleness',
+  'citation_laundering',
+  'direct_fact',
+] as const;
+
+describe('runClaimKitComparison', () => {
+  beforeEach(() => {
+    vi.mocked(claimKitAdapter.initialize).mockResolvedValue(true);
+    vi.mocked(assembleContextPacket).mockResolvedValue(makeRagPacket() as never);
+    vi.mocked(claimKitAdapter.query).mockResolvedValue(makeCkResult() as never);
+  });
+
+  describe('winner determination', () => {
+    it('returns claimkit winner when confidence > 0.5 and answerable', async () => {
+      vi.mocked(claimKitAdapter.query).mockResolvedValue(
+        makeCkResult({ confidence: 0.9, answerability: 'answerable' }) as never,
+      );
+      const result = await runClaimKitComparison({
+        queries: ['test query'],
+        categories: [...ALL_CATEGORIES],
+      });
+      expect(result.cases[0].overallWinner).toBe('claimkit');
+      expect(result.aggregate.wins.claimkit).toBe(1);
+      expect(result.aggregate.wins.rag).toBe(0);
+    });
+
+    it('returns rag winner when ClaimKit is unavailable', async () => {
+      vi.mocked(claimKitAdapter.initialize).mockResolvedValue(false);
+      const result = await runClaimKitComparison({
+        queries: ['test query'],
+        categories: [...ALL_CATEGORIES],
+      });
+      expect(result.cases[0].overallWinner).toBe('rag');
+      expect(result.cases[0].claimkit).toBeNull();
+      expect(result.aggregate.wins.rag).toBe(1);
+    });
+
+    it('returns rag winner when ClaimKit query throws', async () => {
+      vi.mocked(claimKitAdapter.query).mockRejectedValue(new Error('network error'));
+      const result = await runClaimKitComparison({
+        queries: ['test query'],
+        categories: [...ALL_CATEGORIES],
+      });
+      expect(result.cases[0].overallWinner).toBe('rag');
+      expect(result.cases[0].claimkit).toBeNull();
+    });
+
+    it('returns rag winner when confidence < 0.3', async () => {
+      vi.mocked(claimKitAdapter.query).mockResolvedValue(
+        makeCkResult({ confidence: 0.2, answerability: 'answerable' }) as never,
+      );
+      const result = await runClaimKitComparison({
+        queries: ['test query'],
+        categories: [...ALL_CATEGORIES],
+      });
+      expect(result.cases[0].overallWinner).toBe('rag');
+    });
+
+    it('returns rag winner when answerability is not_answerable', async () => {
+      vi.mocked(claimKitAdapter.query).mockResolvedValue(
+        makeCkResult({ confidence: 0.8, answerability: 'not_answerable' }) as never,
+      );
+      const result = await runClaimKitComparison({
+        queries: ['test query'],
+        categories: [...ALL_CATEGORIES],
+      });
+      expect(result.cases[0].overallWinner).toBe('rag');
+    });
+
+    it('returns tie when confidence is between 0.3 and 0.5', async () => {
+      vi.mocked(claimKitAdapter.query).mockResolvedValue(
+        makeCkResult({ confidence: 0.4, answerability: 'partially_answerable' }) as never,
+      );
+      const result = await runClaimKitComparison({
+        queries: ['test query'],
+        categories: [...ALL_CATEGORIES],
+      });
+      expect(result.cases[0].overallWinner).toBe('tie');
+      expect(result.aggregate.wins.tie).toBe(1);
+    });
+
+    it('returns tie when confidence is exactly 0.5 and answerable', async () => {
+      vi.mocked(claimKitAdapter.query).mockResolvedValue(
+        makeCkResult({ confidence: 0.5, answerability: 'answerable' }) as never,
+      );
+      const result = await runClaimKitComparison({
+        queries: ['test query'],
+        categories: [...ALL_CATEGORIES],
+      });
+      // 0.5 is not > 0.5, so it falls through to tie check
+      expect(result.cases[0].overallWinner).toBe('tie');
+    });
+  });
+
+  describe('query categorization', () => {
+    it('categorizes code-related queries as code_retrieval', async () => {
+      const result = await runClaimKitComparison({
+        queries: ['where is the file for auth'],
+        categories: [...ALL_CATEGORIES],
+      });
+      expect(result.cases[0].category).toBe('code_retrieval');
+    });
+
+    it('categorizes function queries as code_retrieval', async () => {
+      const result = await runClaimKitComparison({
+        queries: ['what does this function do'],
+        categories: [...ALL_CATEGORIES],
+      });
+      expect(result.cases[0].category).toBe('code_retrieval');
+    });
+
+    it('categorizes person queries as entity_linking', async () => {
+      const result = await runClaimKitComparison({
+        queries: ['who owns this module'],
+        categories: [...ALL_CATEGORIES],
+      });
+      expect(result.cases[0].category).toBe('entity_linking');
+    });
+
+    it('categorizes date queries as staleness', async () => {
+      const result = await runClaimKitComparison({
+        queries: ['when was this last updated'],
+        categories: [...ALL_CATEGORIES],
+      });
+      expect(result.cases[0].category).toBe('staleness');
+    });
+
+    it('categorizes source queries as citation_laundering', async () => {
+      const result = await runClaimKitComparison({
+        queries: ['what is the source for this claim'],
+        categories: [...ALL_CATEGORIES],
+      });
+      expect(result.cases[0].category).toBe('citation_laundering');
+    });
+
+    it('defaults to direct_fact for unrecognized queries', async () => {
+      const result = await runClaimKitComparison({
+        queries: ['is this correct'],
+        categories: [...ALL_CATEGORIES],
+      });
+      expect(result.cases[0].category).toBe('direct_fact');
+    });
+
+    it('falls back to first allowed category if determined category not in list', async () => {
+      const result = await runClaimKitComparison({
+        queries: ['what does this function do'],
+        categories: ['entity_linking', 'staleness'],
+      });
+      // code_retrieval not in categories, falls back to first: entity_linking
+      expect(result.cases[0].category).toBe('entity_linking');
+    });
+  });
+
+  describe('aggregate stats', () => {
+    it('aggregates wins across multiple queries', async () => {
+      vi.mocked(claimKitAdapter.query)
+        .mockResolvedValueOnce(makeCkResult({ confidence: 0.9, answerability: 'answerable' }) as never)
+        .mockResolvedValueOnce(makeCkResult({ confidence: 0.1, answerability: 'answerable' }) as never)
+        .mockResolvedValueOnce(makeCkResult({ confidence: 0.4, answerability: 'partially_answerable' }) as never);
+
+      const result = await runClaimKitComparison({
+        queries: ['query 1', 'query 2', 'query 3'],
+        categories: [...ALL_CATEGORIES],
+      });
+
+      expect(result.totalCases).toBe(3);
+      expect(result.aggregate.wins.claimkit).toBe(1);
+      expect(result.aggregate.wins.rag).toBe(1);
+      expect(result.aggregate.wins.tie).toBe(1);
+    });
+
+    it('computes correct mean confidence from claimkit results', async () => {
+      vi.mocked(claimKitAdapter.query)
+        .mockResolvedValueOnce(makeCkResult({ confidence: 0.6 }) as never)
+        .mockResolvedValueOnce(makeCkResult({ confidence: 0.8 }) as never);
+
+      const result = await runClaimKitComparison({
+        queries: ['q1', 'q2'],
+        categories: [...ALL_CATEGORIES],
+      });
+
+      expect(result.aggregate.claimkit.mean.confidence).toBeCloseTo(0.7, 5);
+    });
+
+    it('computes zero stats when ClaimKit unavailable', async () => {
+      vi.mocked(claimKitAdapter.initialize).mockResolvedValue(false);
+
+      const result = await runClaimKitComparison({
+        queries: ['q1'],
+        categories: [...ALL_CATEGORIES],
+      });
+
+      expect(result.aggregate.claimkit.mean.confidence).toBe(0);
+      expect(result.aggregate.claimkit.mean.answerabilityRate).toBe(0);
+      expect(result.aggregate.claimkit.mean.avgClaims).toBe(0);
+    });
+
+    it('computes rag stats from packet data', async () => {
+      vi.mocked(assembleContextPacket)
+        .mockResolvedValueOnce(makeRagPacket({ totalTokens: 500, sections: [{ name: 'a' }] }) as never)
+        .mockResolvedValueOnce(makeRagPacket({ totalTokens: 1500, sections: [{ name: 'a' }, { name: 'b' }, { name: 'c' }] }) as never);
+
+      const result = await runClaimKitComparison({
+        queries: ['q1', 'q2'],
+        categories: [...ALL_CATEGORIES],
+      });
+
+      expect(result.aggregate.rag.mean.avgTokens).toBe(1000);
+      expect(result.aggregate.rag.mean.avgSections).toBe(2);
+    });
+
+    it('handles empty query list', async () => {
+      const result = await runClaimKitComparison({
+        queries: [],
+        categories: [...ALL_CATEGORIES],
+      });
+
+      expect(result.totalCases).toBe(0);
+      expect(result.cases).toHaveLength(0);
+      expect(result.aggregate.wins.claimkit).toBe(0);
+      expect(result.aggregate.rag.mean.avgTokens).toBe(0);
+      expect(result.aggregate.claimkit.mean.confidence).toBe(0);
+    });
+  });
+
+  describe('threshold evaluation', () => {
+    it('includes thresholdEvaluation in result', async () => {
+      vi.mocked(claimKitAdapter.query).mockResolvedValue(
+        makeCkResult({ confidence: 0.9, answerability: 'answerable' }) as never,
+      );
+      const result = await runClaimKitComparison({
+        queries: ['test'],
+        categories: [...ALL_CATEGORIES],
+      });
+      expect(result.thresholdEvaluation).toBeDefined();
+      expect(typeof result.thresholdEvaluation?.passed).toBe('boolean');
+    });
+
+    it('uses custom thresholds when provided', async () => {
+      vi.mocked(claimKitAdapter.initialize).mockResolvedValue(false);
+
+      const result = await runClaimKitComparison({
+        queries: ['q1'],
+        categories: [...ALL_CATEGORIES],
+        thresholds: {
+          minClaimKitWinRate: 0,
+          minClaimKitConfidence: 0,
+          minAnswerabilityRate: 0,
+          maxAvgProcessingTimeMs: 999999,
+        },
+      });
+
+      expect(result.thresholdEvaluation?.passed).toBe(true);
+      expect(result.thresholdEvaluation?.failures).toHaveLength(0);
+    });
+
+    it('reports threshold failures when claimkit underperforms', async () => {
+      vi.mocked(claimKitAdapter.initialize).mockResolvedValue(false);
+
+      const result = await runClaimKitComparison({
+        queries: ['q1', 'q2'],
+        categories: [...ALL_CATEGORIES],
+      });
+
+      // With no ClaimKit wins and default thresholds requiring 50% win rate, should fail
+      expect(result.thresholdEvaluation?.passed).toBe(false);
+      expect(result.thresholdEvaluation?.failures.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('case data population', () => {
+    it('records contradictions count from claimkit result', async () => {
+      vi.mocked(claimKitAdapter.query).mockResolvedValue(
+        makeCkResult({
+          confidence: 0.9,
+          answerability: 'answerable',
+          contradictions: [
+            { claimA: 'a', claimB: 'b', reason: 'conflict' },
+            { claimA: 'c', claimB: 'd', reason: 'mismatch' },
+          ],
+        }) as never,
+      );
+
+      const result = await runClaimKitComparison({
+        queries: ['test'],
+        categories: [...ALL_CATEGORIES],
+      });
+
+      expect(result.cases[0].claimkit?.contradictions).toBe(2);
+    });
+
+    it('records claimCount from metadata', async () => {
+      vi.mocked(claimKitAdapter.query).mockResolvedValue(
+        makeCkResult({ metadata: { sourceIds: [], claimCount: 12, processingTimeMs: 80, retrievalScore: 0.7 } }) as never,
+      );
+
+      const result = await runClaimKitComparison({
+        queries: ['test'],
+        categories: [...ALL_CATEGORIES],
+      });
+
+      expect(result.cases[0].claimkit?.claimCount).toBe(12);
+    });
+
+    it('records rag section count from packet sections', async () => {
+      vi.mocked(assembleContextPacket).mockResolvedValue(
+        makeRagPacket({ sections: [{ name: 'a' }, { name: 'b' }, { name: 'c' }, { name: 'd' }] }) as never,
+      );
+
+      const result = await runClaimKitComparison({
+        queries: ['test'],
+        categories: [...ALL_CATEGORIES],
+      });
+
+      expect(result.cases[0].rag.sections).toBe(4);
+    });
+  });
+});


### PR DESCRIPTION
Closes #86

_Generated by AiRemoteCoder autonomous agent._