### PR TITLE
[AI] Preferentially use ClaimKit answer when confidence is high instead of always including both RAG and CK equally

### DIFF
--- a/src/context-engine/context-packet.ts
+++ b/src/context-engine/context-packet.ts
@@ -14,6 +14,8 @@ import type {
   ContextSection,
   ClaimKitContextSection,
   ScoredDocument,
+  PreferredSource,
+  RoutingTier,
 } from "./types";
 import { claimKitAdapter } from "./adapters/claimkit-adapter";
 import { saveLiveComparison } from "../comparison-runs/auto-capture";
@@ -21,6 +23,37 @@ import { createBudget, estimateTokens, enforceBudget } from "./budget";
 import { compressDocuments } from "./compressor";
 import { rerank } from "./reranker";
 import { scoreMessages, deduplicateByJaccard, selectMessages } from "./memory-decay";
+import type { ClaimKitQueryResult } from "./adapters/claimkit-adapter";
+
+export interface RoutingDecision {
+  tier: RoutingTier;
+  preferredSource: PreferredSource;
+  overallWinner: "rag" | "claimkit" | "tie";
+  routingReason: string;
+}
+
+export function determineRoutingTier(ckResult: ClaimKitQueryResult | null): RoutingDecision {
+  if (!ckResult) {
+    return { tier: "rag_primary", preferredSource: "rag", overallWinner: "rag", routingReason: "ck_unavailable" };
+  }
+
+  const { confidence, answerability } = ckResult;
+
+  if (confidence > 0.7 && answerability === "answerable") {
+    return { tier: "ck_primary", preferredSource: "claimkit", overallWinner: "claimkit", routingReason: "high_confidence" };
+  }
+
+  if (confidence < 0.3 || answerability === "not_answerable") {
+    return {
+      tier: "rag_primary",
+      preferredSource: "rag",
+      overallWinner: "rag",
+      routingReason: answerability === "not_answerable" ? "not_answerable" : "low_confidence",
+    };
+  }
+
+  return { tier: "blended", preferredSource: "blended", overallWinner: "tie", routingReason: "uncertain" };
+}
 
 export async function assembleContextPacket(
   params: AssembleContextParams,
@@ -112,21 +145,8 @@ export async function assembleContextPacket(
       );
     }
 
-    // Auto-save comparison data for dashboard
-    let overallWinner: "rag" | "claimkit" | "tie" = "tie";
-    let winnerReason: string | undefined;
-    if (!claimKitResult) {
-      overallWinner = "rag";
-      winnerReason = "ck_unavailable";
-    } else if (claimKitResult.confidence > 0.5 && claimKitResult.answerability === "answerable") {
-      overallWinner = "claimkit";
-      winnerReason = "high_confidence";
-    } else if (claimKitResult.confidence < 0.3 || claimKitResult.answerability === "not_answerable") {
-      overallWinner = "rag";
-      winnerReason = claimKitResult.answerability === "not_answerable" ? "not_answerable" : "low_confidence";
-    } else {
-      winnerReason = "uncertain";
-    }
+    // Auto-save comparison data for dashboard — use routing decision
+    const comparisonRouting = determineRoutingTier(claimKitResult);
     const ragMs = Date.now() - ragStart;
     saveLiveComparison({
       query,
@@ -142,8 +162,8 @@ export async function assembleContextPacket(
       ckRetrievalScore: claimKitResult?.metadata.retrievalScore ?? null,
       ckSourceCount: claimKitResult?.metadata.sourceIds.length ?? null,
       ckMissingEvidence: claimKitResult?.missingEvidence?.join(", ") ?? null,
-      overallWinner,
-      winnerReason,
+      overallWinner: comparisonRouting.overallWinner,
+      winnerReason: comparisonRouting.routingReason,
     });
   }
 
@@ -157,10 +177,18 @@ export async function assembleContextPacket(
   const knowledgeSection = formatDocumentsSection(compressedDocs);
   const graphSection = trimmedGraph;
 
+  const routing = determineRoutingTier(claimKitResult);
+
   let claimKitSection: ClaimKitContextSection | null = null;
   if (claimKitResult) {
     const evidenceLines: string[] = [];
-    evidenceLines.push("=== VERIFIED EVIDENCE (ClaimKit) ===");
+    if (routing.tier === "ck_primary") {
+      evidenceLines.push("=== PRIMARY ANSWER (ClaimKit — high confidence) ===");
+    } else if (routing.tier === "rag_primary") {
+      evidenceLines.push("=== SUPPLEMENTARY ANALYSIS (ClaimKit) ===");
+    } else {
+      evidenceLines.push("=== VERIFIED EVIDENCE (ClaimKit) ===");
+    }
     evidenceLines.push(`Answerability: ${claimKitResult.answerability}`);
     evidenceLines.push(`Confidence: ${(claimKitResult.confidence * 100).toFixed(1)}%`);
     evidenceLines.push(`Claims found: ${claimKitResult.metadata.claimCount}`);
@@ -212,25 +240,44 @@ export async function assembleContextPacket(
     { role: "system", content: enforced[0].content },
   ];
 
-  if (enforced[2].content.trim()) {
-    messages.push({
-      role: "system",
-      content: `=== RELEVANT CONTEXT ===\n${enforced[2].content}`,
-    });
+  const claimKitEnforced = enforced.find((s) => s.name === "claimkit_evidence");
+  const docEnforced = enforced[2];
+
+  if (routing.tier === "ck_primary" && claimKitEnforced?.content.trim()) {
+    // CK primary: show ClaimKit answer first with full detail
+    messages.push({ role: "system", content: claimKitEnforced.content });
+    if (docEnforced?.content.trim()) {
+      messages.push({
+        role: "system",
+        content: `=== SUPPLEMENTARY CONTEXT ===\n${docEnforced.content}`,
+      });
+    }
+  } else if (routing.tier === "rag_primary" && claimKitEnforced?.content.trim()) {
+    // RAG primary: show RAG first, CK as supplementary
+    if (docEnforced?.content.trim()) {
+      messages.push({
+        role: "system",
+        content: `=== RELEVANT CONTEXT ===\n${docEnforced.content}`,
+      });
+    }
+    messages.push({ role: "system", content: claimKitEnforced.content });
+  } else {
+    // Blended or CK unavailable: current behavior — RAG then CK equally
+    if (docEnforced?.content.trim()) {
+      messages.push({
+        role: "system",
+        content: `=== RELEVANT CONTEXT ===\n${docEnforced.content}`,
+      });
+    }
+    if (claimKitEnforced?.content.trim()) {
+      messages.push({ role: "system", content: claimKitEnforced.content });
+    }
   }
 
   if (enforced[3].content.trim()) {
     messages.push({
       role: "system",
       content: `=== KNOWLEDGE GRAPH ===\n${enforced[3].content}`,
-    });
-  }
-
-  const claimKitEnforced = enforced.find((s) => s.name === "claimkit_evidence");
-  if (claimKitEnforced && claimKitEnforced.content.trim()) {
-    messages.push({
-      role: "system",
-      content: claimKitEnforced.content,
     });
   }
 
@@ -274,6 +321,8 @@ export async function assembleContextPacket(
     sections: enforced,
     messages,
     totalTokens,
+    preferredSource: routing.preferredSource,
+    routingReason: routing.routingReason,
     budgetBreakdown: budget.slots,
     diagnostics: {
       mode: "engine",

--- a/src/context-engine/types.ts
+++ b/src/context-engine/types.ts
@@ -66,11 +66,16 @@ export interface ClaimKitContextSection {
   confidence: number;
 }
 
+export type PreferredSource = "claimkit" | "rag" | "blended";
+export type RoutingTier = "ck_primary" | "rag_primary" | "blended";
+
 export interface ContextPacket {
   sections: ContextSection[];
   messages: ChatMessage[];
   totalTokens: number;
   claimkitSection?: ClaimKitContextSection;
+  preferredSource?: PreferredSource;
+  routingReason?: string;
   budgetBreakdown: BudgetSlot[];
   diagnostics: {
     mode: ContextMode;

--- a/tests/unit/comparison-runs/context-packet.test.ts
+++ b/tests/unit/comparison-runs/context-packet.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import {
+  determineRoutingTier,
+  type RoutingDecision,
+} from "../../../src/context-engine/context-packet";
+import type { ClaimKitQueryResult } from "../../../src/context-engine/adapters/claimkit-adapter";
+
+function makeCKResult(overrides: Partial<ClaimKitQueryResult> = {}): ClaimKitQueryResult {
+  return {
+    answer: "Test answer",
+    citations: [],
+    confidence: 0.8,
+    contradictions: [],
+    missingEvidence: [],
+    answerability: "answerable",
+    metadata: {
+      sourceIds: ["src-1"],
+      claimCount: 3,
+      processingTimeMs: 100,
+      retrievalScore: 0.85,
+    },
+    ...overrides,
+  };
+}
+
+describe("determineRoutingTier", () => {
+  describe("CK primary tier (confidence > 0.7 AND answerable)", () => {
+    it("routes to claimkit when confidence is 0.75 and answerable", () => {
+      const result = makeCKResult({ confidence: 0.75, answerability: "answerable" });
+      const decision = determineRoutingTier(result);
+      expect(decision.tier).toBe("ck_primary");
+      expect(decision.preferredSource).toBe("claimkit");
+      expect(decision.overallWinner).toBe("claimkit");
+      expect(decision.routingReason).toBe("high_confidence");
+    });
+
+    it("routes to claimkit when confidence is exactly 0.7 is NOT CK primary (boundary)", () => {
+      const result = makeCKResult({ confidence: 0.7, answerability: "answerable" });
+      const decision = determineRoutingTier(result);
+      expect(decision.tier).toBe("blended");
+    });
+
+    it("routes to claimkit at very high confidence 0.95", () => {
+      const result = makeCKResult({ confidence: 0.95, answerability: "answerable" });
+      const decision = determineRoutingTier(result);
+      expect(decision.tier).toBe("ck_primary");
+      expect(decision.preferredSource).toBe("claimkit");
+    });
+
+    it("does NOT route to CK primary when partially-answerable even with high confidence", () => {
+      const result = makeCKResult({ confidence: 0.8, answerability: "partially-answerable" });
+      const decision = determineRoutingTier(result);
+      expect(decision.tier).not.toBe("ck_primary");
+    });
+  });
+
+  describe("RAG primary tier (confidence < 0.3 OR not_answerable OR CK unavailable)", () => {
+    it("routes to RAG when confidence is 0.25", () => {
+      const result = makeCKResult({ confidence: 0.25, answerability: "answerable" });
+      const decision = determineRoutingTier(result);
+      expect(decision.tier).toBe("rag_primary");
+      expect(decision.preferredSource).toBe("rag");
+      expect(decision.overallWinner).toBe("rag");
+      expect(decision.routingReason).toBe("low_confidence");
+    });
+
+    it("routes to RAG when confidence is exactly 0.3 is NOT RAG primary (boundary)", () => {
+      const result = makeCKResult({ confidence: 0.3, answerability: "answerable" });
+      const decision = determineRoutingTier(result);
+      expect(decision.tier).toBe("blended");
+    });
+
+    it("routes to RAG when answerability is not_answerable", () => {
+      const result = makeCKResult({ confidence: 0.6, answerability: "not_answerable" });
+      const decision = determineRoutingTier(result);
+      expect(decision.tier).toBe("rag_primary");
+      expect(decision.routingReason).toBe("not_answerable");
+    });
+
+    it("routes to RAG when CK result is null (unavailable)", () => {
+      const decision = determineRoutingTier(null);
+      expect(decision.tier).toBe("rag_primary");
+      expect(decision.preferredSource).toBe("rag");
+      expect(decision.overallWinner).toBe("rag");
+      expect(decision.routingReason).toBe("ck_unavailable");
+    });
+
+    it("routes to RAG when confidence is very low 0.05", () => {
+      const result = makeCKResult({ confidence: 0.05, answerability: "answerable" });
+      const decision = determineRoutingTier(result);
+      expect(decision.tier).toBe("rag_primary");
+    });
+  });
+
+  describe("Blended tier (0.3-0.7, answerable or partially-answerable)", () => {
+    it("routes to blended when confidence is 0.5 and answerable", () => {
+      const result = makeCKResult({ confidence: 0.5, answerability: "answerable" });
+      const decision = determineRoutingTier(result);
+      expect(decision.tier).toBe("blended");
+      expect(decision.preferredSource).toBe("blended");
+      expect(decision.overallWinner).toBe("tie");
+      expect(decision.routingReason).toBe("uncertain");
+    });
+
+    it("routes to blended at lower boundary 0.3", () => {
+      const result = makeCKResult({ confidence: 0.3, answerability: "answerable" });
+      const decision = determineRoutingTier(result);
+      expect(decision.tier).toBe("blended");
+    });
+
+    it("routes to blended at upper boundary 0.7", () => {
+      const result = makeCKResult({ confidence: 0.7, answerability: "answerable" });
+      const decision = determineRoutingTier(result);
+      expect(decision.tier).toBe("blended");
+    });
+
+    it("routes to blended when partially-answerable with moderate confidence", () => {
+      const result = makeCKResult({ confidence: 0.5, answerability: "partially-answerable" });
+      const decision = determineRoutingTier(result);
+      expect(decision.tier).toBe("blended");
+      expect(decision.routingReason).toBe("uncertain");
+    });
+  });
+
+  describe("RoutingDecision type structure", () => {
+    it("returns all required fields", () => {
+      const result = makeCKResult({ confidence: 0.85, answerability: "answerable" });
+      const decision = determineRoutingTier(result);
+      expect(decision).toHaveProperty("tier");
+      expect(decision).toHaveProperty("preferredSource");
+      expect(decision).toHaveProperty("overallWinner");
+      expect(decision).toHaveProperty("routingReason");
+    });
+  });
+});

--- a/tests/unit/context-engine/context-packet.test.ts
+++ b/tests/unit/context-engine/context-packet.test.ts
@@ -139,7 +139,8 @@ describe("assembleContextPacket - ClaimKit integration", () => {
 
     const claimKitSection = packet.sections.find((s) => s.name === "claimkit_evidence");
     expect(claimKitSection).toBeDefined();
-    expect(claimKitSection!.content).toContain("VERIFIED EVIDENCE (ClaimKit)");
+    // With confidence 0.85 and answerable, this routes to ck_primary
+    expect(claimKitSection!.content).toContain("PRIMARY ANSWER (ClaimKit — high confidence)");
     expect(claimKitSection!.content).toContain("Answerability: answerable");
   });
 
@@ -149,7 +150,7 @@ describe("assembleContextPacket - ClaimKit integration", () => {
     const packet = await assembleContextPacket(baseParams);
 
     const claimKitMessage = packet.messages.find(
-      (m) => m.role === "system" && m.content?.includes("VERIFIED EVIDENCE (ClaimKit)"),
+      (m) => m.role === "system" && m.content?.includes("PRIMARY ANSWER (ClaimKit"),
     );
     expect(claimKitMessage).toBeDefined();
   });


### PR DESCRIPTION
Closes #126

_Generated by AiRemoteCoder autonomous agent._