### PR TITLE
[AI] [SPRINT-1] [Kanban S1.1] Migrate agent_runs schema: add issue linkage + worktree columns

### DIFF
--- a/src/agent-runs/__tests__/schema-migration.test.ts
+++ b/src/agent-runs/__tests__/schema-migration.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { AgentRunDatabase } from '../database';
+
+describe('Schema migration: issue linkage + worktree columns', () => {
+  let db: AgentRunDatabase;
+
+  beforeEach(() => {
+    db = new AgentRunDatabase(':memory:');
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('should create the idx_agent_runs_issue composite index', () => {
+    const indexes = (db as unknown as { db: { prepare(sql: string): { all(): Array<{ name: string }> } } })
+      .db.prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_agent_runs_issue'")
+      .all();
+    expect(indexes).toHaveLength(1);
+    expect(indexes[0].name).toBe('idx_agent_runs_issue');
+  });
+
+  it('should expose issue_id, issue_platform, issue_repo columns in the schema', () => {
+    const columns = (db as unknown as { db: { prepare(sql: string): { all(): Array<{ name: string }> } } })
+      .db.prepare("PRAGMA table_info(agent_runs)")
+      .all()
+      .map((c) => c.name);
+    expect(columns).toContain('issue_id');
+    expect(columns).toContain('issue_platform');
+    expect(columns).toContain('issue_repo');
+  });
+
+  it('should expose worktree_path and branch columns in the schema', () => {
+    const columns = (db as unknown as { db: { prepare(sql: string): { all(): Array<{ name: string }> } } })
+      .db.prepare("PRAGMA table_info(agent_runs)")
+      .all()
+      .map((c) => c.name);
+    expect(columns).toContain('worktree_path');
+    expect(columns).toContain('branch');
+  });
+
+  it('should persist issue linkage fields via startRun', () => {
+    const run = db.startRun({
+      sessionId: 'sess-1',
+      userId: 'user-1',
+      mode: 'productivity',
+      issueId: '129',
+      issuePlatform: 'github',
+      issueRepo: 'redsand/AIWorkAssistant',
+    });
+    expect(run.issueId).toBe('129');
+    expect(run.issuePlatform).toBe('github');
+    expect(run.issueRepo).toBe('redsand/AIWorkAssistant');
+
+    const fetched = db.getRun(run.id);
+    expect(fetched?.issueId).toBe('129');
+    expect(fetched?.issuePlatform).toBe('github');
+    expect(fetched?.issueRepo).toBe('redsand/AIWorkAssistant');
+  });
+
+  it('should persist worktree_path and branch via startRun', () => {
+    const run = db.startRun({
+      userId: 'user-1',
+      mode: 'engineering',
+      worktreePath: '/tmp/worktrees/issue-129',
+      branch: 'ai/issue-129',
+    });
+    expect(run.worktreePath).toBe('/tmp/worktrees/issue-129');
+    expect(run.branch).toBe('ai/issue-129');
+
+    const fetched = db.getRun(run.id);
+    expect(fetched?.worktreePath).toBe('/tmp/worktrees/issue-129');
+    expect(fetched?.branch).toBe('ai/issue-129');
+  });
+
+  it('should not break existing callers — new fields default to null', () => {
+    const run = db.startRun({ userId: 'user-1', mode: 'productivity' });
+    expect(run.issueId).toBeNull();
+    expect(run.issuePlatform).toBeNull();
+    expect(run.issueRepo).toBeNull();
+    expect(run.worktreePath).toBeNull();
+    expect(run.branch).toBeNull();
+
+    const fetched = db.getRun(run.id);
+    expect(fetched?.issueId).toBeNull();
+    expect(fetched?.issuePlatform).toBeNull();
+    expect(fetched?.issueRepo).toBeNull();
+    expect(fetched?.worktreePath).toBeNull();
+    expect(fetched?.branch).toBeNull();
+  });
+
+  it('should return new fields in listRuns results', () => {
+    db.startRun({
+      userId: 'user-1',
+      mode: 'productivity',
+      issueId: '42',
+      issuePlatform: 'jira',
+      issueRepo: 'PROJ',
+      worktreePath: '/wt/42',
+      branch: 'fix/42',
+    });
+    const result = db.listRuns({ userId: 'user-1' });
+    expect(result.runs).toHaveLength(1);
+    expect(result.runs[0].issueId).toBe('42');
+    expect(result.runs[0].issuePlatform).toBe('jira');
+    expect(result.runs[0].issueRepo).toBe('PROJ');
+    expect(result.runs[0].worktreePath).toBe('/wt/42');
+    expect(result.runs[0].branch).toBe('fix/42');
+  });
+
+  it('should survive schema re-initialization without error', () => {
+    // Simulate re-opening the database on an existing file
+    const db2 = new AgentRunDatabase(':memory:');
+    const run = db2.startRun({
+      userId: 'user-1',
+      mode: 'productivity',
+      issueId: '99',
+      issuePlatform: 'gitlab',
+    });
+    expect(run.issueId).toBe('99');
+    db2.close();
+  });
+});

--- a/src/agent-runs/database.ts
+++ b/src/agent-runs/database.ts
@@ -77,8 +77,14 @@ class AgentRunDatabase {
     `);
     this.ensureColumn("agent_runs", "last_activity_at", "TEXT");
     this.ensureColumn("agent_runs", "cancelled_at", "TEXT");
+    this.ensureColumn("agent_runs", "issue_id", "TEXT");
+    this.ensureColumn("agent_runs", "issue_platform", "TEXT");
+    this.ensureColumn("agent_runs", "issue_repo", "TEXT");
+    this.ensureColumn("agent_runs", "worktree_path", "TEXT");
+    this.ensureColumn("agent_runs", "branch", "TEXT");
     this.db.exec(`
       CREATE INDEX IF NOT EXISTS idx_agent_runs_last_activity_at ON agent_runs(last_activity_at);
+      CREATE INDEX IF NOT EXISTS idx_agent_runs_issue ON agent_runs(issue_platform, issue_repo, issue_id);
     `);
     this.db
       .prepare(
@@ -102,10 +108,22 @@ class AgentRunDatabase {
     const now = new Date().toISOString();
     this.db
       .prepare(
-        `INSERT INTO agent_runs (id, session_id, user_id, mode, status, started_at, last_activity_at)
-         VALUES (?, ?, ?, ?, 'running', ?, ?)`,
+        `INSERT INTO agent_runs (id, session_id, user_id, mode, status, started_at, last_activity_at, issue_id, issue_platform, issue_repo, worktree_path, branch)
+         VALUES (?, ?, ?, ?, 'running', ?, ?, ?, ?, ?, ?, ?)`,
       )
-      .run(id, params.sessionId ?? null, params.userId, params.mode, now, now);
+      .run(
+        id,
+        params.sessionId ?? null,
+        params.userId,
+        params.mode,
+        now,
+        now,
+        params.issueId ?? null,
+        params.issuePlatform ?? null,
+        params.issueRepo ?? null,
+        params.worktreePath ?? null,
+        params.branch ?? null,
+      );
 
     return {
       id,
@@ -123,6 +141,11 @@ class AgentRunDatabase {
       lastActivityAt: now,
       completedAt: null,
       cancelledAt: null,
+      issueId: params.issueId ?? null,
+      issuePlatform: params.issuePlatform ?? null,
+      issueRepo: params.issueRepo ?? null,
+      worktreePath: params.worktreePath ?? null,
+      branch: params.branch ?? null,
     };
   }
 
@@ -367,6 +390,11 @@ class AgentRunDatabase {
         (row.last_activity_at as string | null) ?? (row.started_at as string),
       completedAt: row.completed_at as string | null,
       cancelledAt: row.cancelled_at as string | null,
+      issueId: (row.issue_id as string | null) ?? null,
+      issuePlatform: (row.issue_platform as string | null) ?? null,
+      issueRepo: (row.issue_repo as string | null) ?? null,
+      worktreePath: (row.worktree_path as string | null) ?? null,
+      branch: (row.branch as string | null) ?? null,
     };
   }
 

--- a/src/agent-runs/types.ts
+++ b/src/agent-runs/types.ts
@@ -14,6 +14,11 @@ export interface AgentRun {
   lastActivityAt: string;
   completedAt: string | null;
   cancelledAt: string | null;
+  issueId: string | null;
+  issuePlatform: string | null;
+  issueRepo: string | null;
+  worktreePath: string | null;
+  branch: string | null;
 }
 
 export interface AgentRunStep {
@@ -57,6 +62,11 @@ export interface AgentRunCreateParams {
   sessionId?: string | null;
   userId: string;
   mode: string;
+  issueId?: string | null;
+  issuePlatform?: string | null;
+  issueRepo?: string | null;
+  worktreePath?: string | null;
+  branch?: string | null;
 }
 
 export interface AgentRunCompleteParams {


### PR DESCRIPTION
Closes #129

_Generated by AiRemoteCoder autonomous agent._