### PR TITLE
[AI] [SPRINT-0] Add per-tool TTL to tool cache to prevent stale mutable state

### DIFF
--- a/src/memory/__tests__/tool-cache.test.ts
+++ b/src/memory/__tests__/tool-cache.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { toolCallCache, type CachedToolCall } from "../tool-cache";
+
+describe("toolCallCache TTL", () => {
+  const sessionId = "test-session";
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    toolCallCache.clear(sessionId);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    toolCallCache.clear(sessionId);
+  });
+
+  function setMutableEntry(toolName: string, ttlMs: number): CachedToolCall {
+    const entry = toolCallCache.set(sessionId, toolName, { id: 1 }, { state: "open" }, "tc-1");
+    expect(entry.ttlMs).toBe(ttlMs);
+    return entry;
+  }
+
+  it("stores a 120s TTL for github.get_issue", () => {
+    const entry = setMutableEntry("github.get_issue", 120_000);
+    expect(entry.toolName).toBe("github.get_issue");
+  });
+
+  it("stores a 60s TTL for github.list_workflow_runs", () => {
+    const entry = setMutableEntry("github.list_workflow_runs", 60_000);
+    expect(entry.toolName).toBe("github.list_workflow_runs");
+  });
+
+  it("stores Infinity TTL for unknown cacheable tools", () => {
+    const entry = toolCallCache.set(
+      sessionId,
+      "filesystem.read_file",
+      { path: "/tmp/foo.txt" },
+      "content",
+      "tc-2",
+    );
+    expect(entry.ttlMs).toBe(Infinity);
+  });
+
+  it("returns mutable data before TTL expires", () => {
+    toolCallCache.set(sessionId, "github.get_issue", { id: 1 }, { state: "open" }, "tc-1");
+    vi.advanceTimersByTime(119_000);
+    const cached = toolCallCache.get(sessionId, "github.get_issue", { id: 1 });
+    expect(cached).not.toBeNull();
+    expect((cached!.result as { state: string }).state).toBe("open");
+  });
+
+  it("returns null and evicts a mutable entry after TTL expires", () => {
+    const entry = toolCallCache.set(
+      sessionId,
+      "github.get_issue",
+      { id: 1 },
+      { state: "open" },
+      "tc-1",
+    );
+    vi.advanceTimersByTime(120_001);
+    const cached = toolCallCache.get(sessionId, "github.get_issue", { id: 1 });
+    expect(cached).toBeNull();
+    expect(toolCallCache.getByRef(entry.ref)).toBeNull();
+    expect(toolCallCache.list(sessionId)).toHaveLength(0);
+  });
+
+  it("returns immutable data regardless of age", () => {
+    toolCallCache.set(
+      sessionId,
+      "filesystem.read_file",
+      { path: "/tmp/foo.txt" },
+      "content",
+      "tc-2",
+    );
+    vi.advanceTimersByTime(7 * 24 * 3600 * 1000); // 7 days
+    const cached = toolCallCache.get(sessionId, "filesystem.read_file", { path: "/tmp/foo.txt" });
+    expect(cached).not.toBeNull();
+    expect(cached!.result).toBe("content");
+  });
+
+  it("evicts expired entries from both bySession and byRef maps on get", () => {
+    const entry = toolCallCache.set(
+      sessionId,
+      "jira.get_issue",
+      { key: "PROJ-1" },
+      { status: "In Progress" },
+      "tc-3",
+    );
+    vi.advanceTimersByTime(120_001);
+    expect(toolCallCache.get(sessionId, "jira.get_issue", { key: "PROJ-1" })).toBeNull();
+    expect(toolCallCache.list(sessionId)).toHaveLength(0);
+    expect(toolCallCache.getByRef(entry.ref)).toBeNull();
+  });
+
+  it("does not cache non-read tools regardless of TTL map", () => {
+    expect(toolCallCache.get(sessionId, "github.create_issue", { title: "x" })).toBeNull();
+    const entry = toolCallCache.set(
+      sessionId,
+      "github.create_issue",
+      { title: "x" },
+      { id: 123 },
+      "tc-4",
+    );
+    expect(entry.ttlMs).toBe(Infinity);
+    expect(toolCallCache.get(sessionId, "github.create_issue", { title: "x" })).toBeNull();
+  });
+
+  it("covers all required mutable-state tools", () => {
+    const mutableTools = [
+      "github.get_issue",
+      "github.get_pull_request",
+      "github.list_issues",
+      "github.list_pull_requests",
+      "github.list_workflow_runs",
+      "github.get_workflow_run",
+      "gitlab.get_issue",
+      "gitlab.get_merge_request",
+      "gitlab.list_merge_requests",
+      "jira.get_issue",
+      "jira.search_issues",
+      "hawk_ir.get_case",
+      "hawk_ir.list_cases",
+      "system.list_approvals",
+    ];
+    for (const toolName of mutableTools) {
+      const entry = toolCallCache.set(sessionId, toolName, {}, { ok: true }, `tc-${toolName}`);
+      expect(entry.ttlMs).toBeLessThan(Infinity);
+      expect(entry.ttlMs).toBeGreaterThan(0);
+    }
+  });
+
+  it("evicts expired entries from both bySession and byRef maps on get", () => {
+    const entry = toolCallCache.set(
+      sessionId,
+      "jira.get_issue",
+      { key: "PROJ-1" },
+      { status: "In Progress" },
+      "tc-3",
+    );
+    vi.advanceTimersByTime(120_001);
+    expect(toolCallCache.get(sessionId, "jira.get_issue", { key: "PROJ-1" })).toBeNull();
+    expect(toolCallCache.list(sessionId)).toHaveLength(0);
+    expect(toolCallCache.getByRef(entry.ref)).toBeNull();
+  });
+
+  it("getByRef returns null for an expired mutable entry", () => {
+    const entry = toolCallCache.set(
+      sessionId,
+      "gitlab.get_merge_request",
+      { iid: 42 },
+      { state: "opened" },
+      "tc-5",
+    );
+    vi.advanceTimersByTime(120_001);
+    expect(toolCallCache.getByRef(entry.ref)).toBeNull();
+    expect(toolCallCache.list(sessionId)).toHaveLength(0);
+  });
+
+  it("buildManifest omits expired mutable entries", () => {
+    toolCallCache.set(sessionId, "github.get_issue", { id: 1 }, { state: "open" }, "tc-1");
+    vi.advanceTimersByTime(120_001);
+    const manifest = toolCallCache.buildManifest(sessionId);
+    expect(manifest).toBe("");
+  });
+});

--- a/src/memory/tool-cache.ts
+++ b/src/memory/tool-cache.ts
@@ -11,6 +11,7 @@ export interface CachedToolCall {
   resultSize: number;
   calledAt: number;
   toolCallId: string;
+  ttlMs: number;
 }
 
 // Patterns identifying read-style tools that produce idempotent results.
@@ -52,6 +53,33 @@ const NEVER_CACHE = new Set<string>([
   "skill.manage",
   "cron.manage",
 ]);
+
+// Tools that return frequently-changing state get a short cache TTL.
+// Everything else keeps session-lifetime caching (immutable reads like
+// file contents, commit history, blame, tree listings).
+const MUTABLE_STATE_TTL_MS: Record<string, number> = {
+  // GitHub — issue/PR state changes on close/merge/label
+  "github.get_issue": 120_000,
+  "github.get_pull_request": 120_000,
+  "github.list_issues": 120_000,
+  "github.list_pull_requests": 120_000,
+  "github.list_workflow_runs": 60_000,
+  "github.get_workflow_run": 60_000,
+  // GitLab — same mutable state patterns
+  "gitlab.get_issue": 120_000,
+  "gitlab.get_merge_request": 120_000,
+  "gitlab.list_merge_requests": 120_000,
+  // Jira — issue status transitions
+  "jira.get_issue": 120_000,
+  "jira.search_issues": 120_000,
+  // HAWK IR — case state changes
+  "hawk_ir.get_case": 60_000,
+  "hawk_ir.list_cases": 60_000,
+  // Approval state changes on approve/reject
+  "system.list_approvals": 60_000,
+};
+
+const DEFAULT_IMMUTABLE_TTL_MS = Infinity; // session lifetime
 
 export function isCacheableTool(canonicalName: string): boolean {
   if (NEVER_CACHE.has(canonicalName)) return false;
@@ -261,7 +289,17 @@ class ToolCallCache {
   ): CachedToolCall | null {
     if (!isCacheableTool(toolName)) return null;
     const key = hashCall(toolName, params);
-    return this.bySession.get(sessionId)?.get(key) ?? null;
+    const entry = this.bySession.get(sessionId)?.get(key) ?? null;
+    if (!entry) return null;
+
+    const ttlMs = entry.ttlMs ?? DEFAULT_IMMUTABLE_TTL_MS;
+    if (ttlMs !== Infinity && (Date.now() - entry.calledAt) > ttlMs) {
+      // Expired — evict from both maps.
+      this.bySession.get(sessionId)?.delete(key);
+      this.byRef.delete(entry.ref);
+      return null;
+    }
+    return entry;
   }
 
   set(
@@ -283,6 +321,7 @@ class ToolCallCache {
     }
     const resultStr =
       typeof result === "string" ? result : JSON.stringify(result ?? null);
+    const ttlMs = MUTABLE_STATE_TTL_MS[toolName] ?? DEFAULT_IMMUTABLE_TTL_MS;
     const entry: CachedToolCall = {
       ref,
       toolName,
@@ -292,6 +331,7 @@ class ToolCallCache {
       resultSize: resultStr.length,
       calledAt: Date.now(),
       toolCallId,
+      ttlMs,
     };
 
     let sessionCache = this.bySession.get(sessionId);
@@ -328,12 +368,32 @@ class ToolCallCache {
   getByRef(ref: string): CachedToolCall | null {
     const lookup = this.byRef.get(ref);
     if (!lookup) return null;
-    return this.bySession.get(lookup.sessionId)?.get(lookup.key) ?? null;
+    const sessionCache = this.bySession.get(lookup.sessionId);
+    if (!sessionCache) return null;
+    const entry = sessionCache.get(lookup.key) ?? null;
+    if (!entry) return null;
+
+    const ttlMs = entry.ttlMs ?? DEFAULT_IMMUTABLE_TTL_MS;
+    if (ttlMs !== Infinity && (Date.now() - entry.calledAt) > ttlMs) {
+      // Expired — evict from both maps.
+      sessionCache.delete(lookup.key);
+      this.byRef.delete(ref);
+      return null;
+    }
+    return entry;
   }
 
   list(sessionId: string): CachedToolCall[] {
     const sessionCache = this.bySession.get(sessionId);
     if (!sessionCache) return [];
+    const now = Date.now();
+    for (const [key, entry] of sessionCache.entries()) {
+      const ttlMs = entry.ttlMs ?? DEFAULT_IMMUTABLE_TTL_MS;
+      if (ttlMs !== Infinity && (now - entry.calledAt) > ttlMs) {
+        sessionCache.delete(key);
+        this.byRef.delete(entry.ref);
+      }
+    }
     return Array.from(sessionCache.values()).sort((a, b) => a.calledAt - b.calledAt);
   }
 


### PR DESCRIPTION
Closes #212

_Generated by AiRemoteCoder autonomous agent._