### PR TITLE
[AI] [SPRINT-6] Implement ClaimKit-first retrieval with confidence-based RAG fallback

### DIFF
--- a/src/comparison-runs/auto-capture.ts
+++ b/src/comparison-runs/auto-capture.ts
@@ -104,6 +104,8 @@ export function saveLiveComparison(params: {
   ckSectionTokens?: number | null;
   /** Phase 1: per-stage confidence trace from ClaimKit (any JSON-serializable shape). */
   confidenceTrace?: unknown;
+  /** ClaimKit-first routing strategy chosen for this query (issue #229). */
+  routingStrategy?: string | null;
   db?: ComparisonRunDatabase;
 }): { caseId: string } | null {
   try {
@@ -128,6 +130,7 @@ export function saveLiveComparison(params: {
           contradictionsFlagged: params.contradictionsFlagged,
           ckSectionTokens: params.ckSectionTokens,
           confidenceTrace: params.confidenceTrace,
+          routingStrategy: params.routingStrategy,
           rag: {
             contextTokens: params.ragTokens,
             sections: params.ragSections,

--- a/src/comparison-runs/database.ts
+++ b/src/comparison-runs/database.ts
@@ -110,6 +110,10 @@ class ComparisonRunDatabase {
       // timings. Lets the dashboard show "why did this query score 0.05?"
       // with a real breakdown instead of a final number.
       { col: "confidence_trace", def: "TEXT" },
+      // ClaimKit-first routing strategy (issue #229): which of the three
+      // ClaimKit-first paths (or rag_first) was chosen for this query. Lets
+      // the dashboard measure RAG-skip rate and per-path latency.
+      { col: "routing_strategy", def: "TEXT" },
     ];
     for (const { col, def } of migrations) {
       try {
@@ -156,6 +160,7 @@ class ComparisonRunDatabase {
           contradictions_flagged INTEGER,
           ck_section_tokens INTEGER,
           confidence_trace TEXT,
+          routing_strategy TEXT,
           created_at TEXT NOT NULL,
           FOREIGN KEY (run_id) REFERENCES comparison_runs(id) ON DELETE CASCADE
         );
@@ -167,6 +172,7 @@ class ComparisonRunDatabase {
                  ck_status, ck_included_in_context,
                  rag_hallucination_rate, rag_grounded,
                  NULL, NULL, NULL, NULL,
+                 NULL,
                  NULL,
                  NULL,
                  created_at
@@ -200,8 +206,9 @@ class ComparisonRunDatabase {
           entity_claims_injected, contradictions_flagged,
           ck_section_tokens,
           confidence_trace,
+          routing_strategy,
           created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     );
 
     const txn = this.db.transaction(() => {
@@ -236,6 +243,7 @@ class ComparisonRunDatabase {
           c.contradictionsFlagged ?? null,
           c.ckSectionTokens ?? null,
           c.confidenceTrace ? JSON.stringify(c.confidenceTrace) : null,
+          c.routingStrategy ?? null,
           now,
         );
       }
@@ -933,6 +941,7 @@ class ComparisonRunDatabase {
       rag_grounded: row.rag_grounded != null ? Boolean(row.rag_grounded) : null,
       ck_section_tokens: row.ck_section_tokens as number | null,
       confidence_trace: (row.confidence_trace as string | null) ?? null,
+      routing_strategy: (row.routing_strategy as string | null) ?? null,
       created_at: row.created_at as string,
     };
   }

--- a/src/comparison-runs/types.ts
+++ b/src/comparison-runs/types.ts
@@ -47,6 +47,8 @@ export interface ComparisonCaseRow {
   ck_section_tokens: number | null;
   /** JSON-encoded ConfidenceTrace (Phase 1 calibration telemetry). */
   confidence_trace: string | null;
+  /** ClaimKit-first routing strategy decided for this query (issue #229). */
+  routing_strategy: string | null;
   created_at: string;
 }
 
@@ -247,6 +249,13 @@ export interface SaveCaseInput {
    * stage-level data instead of a final number.
    */
   confidenceTrace?: unknown;
+  /**
+   * ClaimKit-first routing strategy chosen for this query (issue #229):
+   * "rag_first", "claimkit_first_skip_rag", "claimkit_first_parallel", or
+   * "claimkit_first_fallback". Lets the dashboard measure how often RAG was
+   * skipped and the latency impact of each path.
+   */
+  routingStrategy?: string | null;
   rag: {
     contextTokens: number;
     sections: number;

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -366,6 +366,26 @@ const envSchema = z.object({
   // Each adds one knowledge-store search; cap small to bound latency.
   CLAIMKIT_GAP_FILL_MAX_QUERIES: z.coerce.number().default(3),
 
+  // ClaimKit-first routing (issue #229). When enabled, a quick pre-flight
+  // ClaimKit probe runs BEFORE RAG retrieval. Based on the probe confidence
+  // the assembler either skips RAG entirely (high confidence), runs RAG in
+  // parallel with a full ClaimKit query (medium), or falls back to full RAG
+  // (low confidence / not answerable). Inverts the old "RAG-first, ClaimKit
+  // supplementary" order to "ClaimKit-first, RAG-fallback".
+  CLAIMKIT_FIRST_ROUTING: z
+    .string()
+    .transform((s) => s === "true")
+    .default("true"),
+  // Skip RAG entirely when the probe confidence is at or above this value.
+  CLAIMKIT_HIGH_CONFIDENCE_THRESHOLD: z.coerce.number().default(0.8),
+  // Run RAG in parallel with a full ClaimKit query when the probe confidence
+  // is at or above this value (but below the high threshold). Below this, fall
+  // back to full RAG + full ClaimKit.
+  CLAIMKIT_LOW_CONFIDENCE_THRESHOLD: z.coerce.number().default(0.5),
+  // Hard cap on the pre-flight ClaimKit probe. Kept small so a slow probe
+  // degrades into "rag_first" rather than adding latency to every query.
+  CLAIMKIT_FIRST_PROBE_TIMEOUT_MS: z.coerce.number().default(500),
+
   // Knowledge graph retrieval controls
   KNOWLEDGE_GRAPH_QUERY_ENABLED: z
     .string()

--- a/src/context-engine/__tests__/routing.test.ts
+++ b/src/context-engine/__tests__/routing.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { determineRoutingStrategy } from "../context-packet";
+import { env } from "../../config/env";
+import type { ClaimKitQueryResult } from "../adapters/claimkit-adapter";
+
+// determineRoutingStrategy reads three env fields at call time. `env` is a
+// mutable exported object, so we snapshot and restore the relevant fields
+// around each test rather than re-mocking the whole module.
+
+function probe(
+  confidence: number,
+  answerability: ClaimKitQueryResult["answerability"],
+): ClaimKitQueryResult {
+  return { confidence, answerability } as ClaimKitQueryResult;
+}
+
+describe("determineRoutingStrategy", () => {
+  let saved: {
+    routing: boolean;
+    high: number;
+    low: number;
+  };
+
+  beforeEach(() => {
+    saved = {
+      routing: env.CLAIMKIT_FIRST_ROUTING,
+      high: env.CLAIMKIT_HIGH_CONFIDENCE_THRESHOLD,
+      low: env.CLAIMKIT_LOW_CONFIDENCE_THRESHOLD,
+    };
+    env.CLAIMKIT_FIRST_ROUTING = true;
+    env.CLAIMKIT_HIGH_CONFIDENCE_THRESHOLD = 0.8;
+    env.CLAIMKIT_LOW_CONFIDENCE_THRESHOLD = 0.5;
+  });
+
+  afterEach(() => {
+    env.CLAIMKIT_FIRST_ROUTING = saved.routing;
+    env.CLAIMKIT_HIGH_CONFIDENCE_THRESHOLD = saved.high;
+    env.CLAIMKIT_LOW_CONFIDENCE_THRESHOLD = saved.low;
+  });
+
+  it("returns rag_first when ClaimKit-first routing is disabled", () => {
+    env.CLAIMKIT_FIRST_ROUTING = false;
+    expect(determineRoutingStrategy(probe(0.95, "answerable"))).toBe("rag_first");
+  });
+
+  it("returns rag_first when the probe is null (probe unavailable or threw)", () => {
+    expect(determineRoutingStrategy(null)).toBe("rag_first");
+  });
+
+  it("returns claimkit_first_skip_rag for high confidence + answerable", () => {
+    expect(determineRoutingStrategy(probe(0.95, "answerable"))).toBe(
+      "claimkit_first_skip_rag",
+    );
+  });
+
+  it("returns claimkit_first_skip_rag at exactly the high threshold", () => {
+    expect(determineRoutingStrategy(probe(0.8, "answerable"))).toBe(
+      "claimkit_first_skip_rag",
+    );
+  });
+
+  it("returns claimkit_first_skip_rag for high confidence + partially-answerable", () => {
+    expect(determineRoutingStrategy(probe(0.85, "partially-answerable"))).toBe(
+      "claimkit_first_skip_rag",
+    );
+  });
+
+  it("returns claimkit_first_parallel for medium confidence", () => {
+    expect(determineRoutingStrategy(probe(0.65, "answerable"))).toBe(
+      "claimkit_first_parallel",
+    );
+  });
+
+  it("returns claimkit_first_parallel at exactly the low threshold", () => {
+    expect(determineRoutingStrategy(probe(0.5, "answerable"))).toBe(
+      "claimkit_first_parallel",
+    );
+  });
+
+  it("returns claimkit_first_parallel just below the high threshold", () => {
+    expect(determineRoutingStrategy(probe(0.79, "partially-answerable"))).toBe(
+      "claimkit_first_parallel",
+    );
+  });
+
+  it("returns claimkit_first_fallback for low confidence + answerable", () => {
+    expect(determineRoutingStrategy(probe(0.3, "answerable"))).toBe(
+      "claimkit_first_fallback",
+    );
+  });
+
+  it("returns claimkit_first_fallback just below the low threshold", () => {
+    expect(determineRoutingStrategy(probe(0.49, "answerable"))).toBe(
+      "claimkit_first_fallback",
+    );
+  });
+
+  it("returns claimkit_first_fallback for not_answerable regardless of high confidence", () => {
+    expect(determineRoutingStrategy(probe(0.99, "not_answerable"))).toBe(
+      "claimkit_first_fallback",
+    );
+  });
+
+  it("respects custom thresholds from env", () => {
+    env.CLAIMKIT_HIGH_CONFIDENCE_THRESHOLD = 0.9;
+    env.CLAIMKIT_LOW_CONFIDENCE_THRESHOLD = 0.6;
+    // 0.85 is now below the (raised) high threshold but above the low one.
+    expect(determineRoutingStrategy(probe(0.85, "answerable"))).toBe(
+      "claimkit_first_parallel",
+    );
+    // 0.55 is now below the (raised) low threshold.
+    expect(determineRoutingStrategy(probe(0.55, "answerable"))).toBe(
+      "claimkit_first_fallback",
+    );
+  });
+});

--- a/src/context-engine/context-packet.ts
+++ b/src/context-engine/context-packet.ts
@@ -17,6 +17,7 @@ import type {
   ScoredDocument,
   PreferredSource,
   RoutingTier,
+  RoutingStrategy,
   GroundingHandle,
 } from "./types";
 import { claimKitAdapter } from "./adapters/claimkit-adapter";
@@ -44,6 +45,12 @@ export interface RoutingDecision {
   overallWinner: "rag" | "claimkit" | "tie";
   routingReason: string;
 }
+
+// Most-recently-observed RAG retrieval latency (ms). Used to estimate the
+// time saved when a high-confidence ClaimKit probe lets us skip RAG (issue
+// #229). Seeded to 0 so the first-ever skip reports no estimated savings
+// rather than a fabricated number.
+let recentRagRetrievalMs = 0;
 
 const INSUFFICIENT_EVIDENCE_PATTERNS = [
   "insufficient evidence to answer this question",
@@ -94,6 +101,38 @@ export function determineRoutingTier(ckResult: ClaimKitQueryResult | null, ckUna
   }
 
   return { tier: "blended", preferredSource: "blended", overallWinner: "tie", routingReason: "uncertain" };
+}
+
+/**
+ * Decide the ClaimKit-first routing strategy from a pre-flight probe (issue
+ * #229). Confidence drives the choice; a non-answerable probe always falls
+ * back to full RAG regardless of confidence so a confidently-wrong "I can't
+ * answer" never skips retrieval.
+ *
+ * - Routing disabled / no probe → "rag_first" (legacy order).
+ * - not_answerable → "claimkit_first_fallback".
+ * - confidence ≥ HIGH threshold → "claimkit_first_skip_rag".
+ * - confidence ≥ LOW threshold → "claimkit_first_parallel".
+ * - otherwise → "claimkit_first_fallback".
+ */
+export function determineRoutingStrategy(
+  ckProbe: ClaimKitQueryResult | null,
+): RoutingStrategy {
+  if (!env.CLAIMKIT_FIRST_ROUTING) return "rag_first";
+  if (!ckProbe) return "rag_first";
+
+  const answerable =
+    ckProbe.answerability === "answerable" ||
+    ckProbe.answerability === "partially-answerable";
+  if (!answerable) return "claimkit_first_fallback";
+
+  if (ckProbe.confidence >= env.CLAIMKIT_HIGH_CONFIDENCE_THRESHOLD) {
+    return "claimkit_first_skip_rag";
+  }
+  if (ckProbe.confidence >= env.CLAIMKIT_LOW_CONFIDENCE_THRESHOLD) {
+    return "claimkit_first_parallel";
+  }
+  return "claimkit_first_fallback";
 }
 
 async function withTimeout<T>(
@@ -237,6 +276,38 @@ export async function assembleContextPacket(
     console.warn(`[ClaimKit] Skipped — ${claimKitAdapter.getInitError()}`);
   }
 
+  // ── ClaimKit-first pre-flight probe (issue #229) ─────────────────────
+  // Query ClaimKit BEFORE running RAG. A high-confidence probe lets us skip
+  // RAG entirely; medium confidence runs both in parallel; low confidence /
+  // not-answerable falls back to full RAG. The probe is hard-capped so a slow
+  // ClaimKit degrades into "rag_first" rather than adding latency. Any error
+  // also degrades to "rag_first".
+  let routingStrategy: RoutingStrategy = "rag_first";
+  let ckProbe: ClaimKitQueryResult | null = null;
+  let probeLatencyMs = 0;
+  if (env.CLAIMKIT_FIRST_ROUTING && env.CLAIMKIT_ENABLED && claimKitAvailable) {
+    onProgress?.("Probing structured claims...");
+    const probeStart = Date.now();
+    try {
+      ckProbe = await withAbortableTimeout(
+        (signal) => claimKitAdapter.query(query, { signal }),
+        env.CLAIMKIT_FIRST_PROBE_TIMEOUT_MS,
+        null,
+      );
+    } catch (err) {
+      ckProbe = null;
+      console.warn("[ContextPacket] ClaimKit-first probe failed:", err instanceof Error ? err.message : err);
+    }
+    probeLatencyMs = Date.now() - probeStart;
+    stageTimings.claimkitProbeMs = probeLatencyMs;
+    routingStrategy = determineRoutingStrategy(ckProbe);
+    console.log(
+      `[ContextPacket] ${routingStrategy} | probe_confidence=${ckProbe ? (ckProbe.confidence * 100).toFixed(0) + "%" : "—"} | ` +
+      `probe_answerability=${ckProbe?.answerability ?? "—"} | probe=${probeLatencyMs}ms`,
+    );
+  }
+  const ragSkipped = routingStrategy === "claimkit_first_skip_rag";
+
   const baseSystemPrompt = getSystemPrompt(mode, query, "engine");
   const systemTokens = estimateTokens(baseSystemPrompt);
   // Pre-V2 only: memory/skills/soul/reflections were not budgeted, so the code
@@ -253,13 +324,25 @@ export async function assembleContextPacket(
   const ragStart = Date.now();
 
   const [docs, selectedMessages] = await Promise.all([
-    timeStage("retrieveStoresMs", () => retrieveAllStores(query)),
+    // ClaimKit-first skip: the high-confidence probe already answered, so we
+    // pay none of the RAG retrieval cost (embedding lookup, keyword search,
+    // graph traversal).
+    ragSkipped
+      ? Promise.resolve([] as ScoredDocument[])
+      : timeStage("retrieveStoresMs", () => retrieveAllStores(query)),
     Promise.resolve().then(() => {
       const scored = scoreMessages(sessionMessages, query);
       const deduped = deduplicateByJaccard(scored);
       return selectMessages(deduped, historySlot.allocatedTokens);
     }),
   ]);
+
+  // Estimate the latency change vs. the old RAG-first path (negative = faster).
+  // When RAG was skipped, the savings is the most-recently-observed RAG
+  // retrieval cost; when RAG ran, the probe added its own latency on top.
+  const ragRetrievalMs = stageTimings.retrieveStoresMs ?? 0;
+  if (!ragSkipped) recentRagRetrievalMs = ragRetrievalMs;
+  const latencyDeltaMs = ragSkipped ? -recentRagRetrievalMs : probeLatencyMs;
 
   const historyTokens = selectedMessages.reduce((sum, s) => sum + s.tokens, 0);
 
@@ -302,6 +385,22 @@ export async function assembleContextPacket(
   } else if (!claimKitAvailable) {
     ckStatus = "disabled";
     console.warn("[ClaimKit] Skipped — not initialized (run `claimkit ingest` to populate stores)");
+  } else if (ragSkipped) {
+    // ClaimKit-first skip path: the high-confidence pre-flight probe already
+    // answered. Reuse it directly — no document seeding (we have no RAG docs)
+    // and no second ClaimKit query.
+    claimKitResult = ckProbe;
+    ckMs = probeLatencyMs;
+    stageTimings.claimkitQueryMs = ckMs;
+    ckStatus = claimKitResult
+      ? (claimKitResult.metadata.claimCount === 0 ? "no_claims" : "answered")
+      : "timeout";
+    if (claimKitResult) {
+      const symbol = claimKitResult.answerability === "answerable" ? "✅" : claimKitResult.answerability === "partially-answerable" ? "⚠️" : "❌";
+      console.log(
+        `[ClaimKit] ${symbol} ${claimKitResult.answerability} | confidence=${(claimKitResult.confidence * 100).toFixed(0)}% | claims=${claimKitResult.metadata.claimCount} | sources=${claimKitResult.metadata.sourceIds.length} | score=${claimKitResult.metadata.retrievalScore.toFixed(2)} | ${ckMs}ms (probe, RAG skipped)`,
+      );
+    }
   } else {
     onProgress?.("Extracting knowledge claims...");
     const seedStart = Date.now();
@@ -624,6 +723,9 @@ export async function assembleContextPacket(
       gapFillDocsAdded,
       entityClaimsInjected: entityClaimsInjectedCount,
       contradictionsFlagged: contradictionsFlaggedCount,
+      // ClaimKit-first routing strategy (issue #229) so the dashboard can
+      // measure RAG-skip rate and latency delta vs. the old RAG-first path.
+      routingStrategy,
     });
 
     // Stash the case ID + compressed RAG evidence so chat.ts can run live
@@ -1059,6 +1161,12 @@ export async function assembleContextPacket(
           : 1,
       budgetUtilization,
       stageTimings,
+      claimkitFirstMetrics: {
+        strategy: routingStrategy,
+        probeLatencyMs,
+        ragSkipped,
+        latencyDeltaMs,
+      },
       claimkit: {
         enabled: env.CLAIMKIT_ENABLED,
         available: claimKitAvailable,

--- a/src/context-engine/types.ts
+++ b/src/context-engine/types.ts
@@ -127,6 +127,43 @@ export type PreferredSource = "claimkit" | "rag" | "blended";
 export type RoutingTier = "ck_primary" | "rag_primary" | "blended";
 
 /**
+ * ClaimKit-first routing strategy (issue #229), decided by a pre-flight
+ * ClaimKit probe before RAG retrieval runs:
+ * - "rag_first": legacy order — ClaimKit-first routing disabled, probe
+ *   unavailable, or probe threw. RAG retrieval runs as before.
+ * - "claimkit_first_skip_rag": probe answered with high confidence; RAG
+ *   retrieval is skipped entirely and the probe answer is used directly.
+ * - "claimkit_first_parallel": probe was medium confidence; RAG runs in
+ *   parallel with a full ClaimKit query so neither adds serial latency.
+ * - "claimkit_first_fallback": probe was low confidence / not answerable;
+ *   fall back to full RAG + full ClaimKit.
+ */
+export type RoutingStrategy =
+  | "rag_first"
+  | "claimkit_first_skip_rag"
+  | "claimkit_first_parallel"
+  | "claimkit_first_fallback";
+
+/**
+ * Telemetry for the ClaimKit-first routing decision. Recorded on every
+ * packet so the comparison dashboard can show how often RAG was skipped and
+ * the latency delta vs. the old RAG-first path.
+ */
+export interface ClaimKitFirstMetrics {
+  strategy: RoutingStrategy;
+  /** Wall-clock latency of the pre-flight ClaimKit probe (0 when not run). */
+  probeLatencyMs: number;
+  /** True when RAG retrieval was skipped because the probe was high-confidence. */
+  ragSkipped: boolean;
+  /**
+   * Estimated latency change vs. the old RAG-first path. Negative = faster.
+   * When RAG was skipped this is the (estimated) RAG retrieval cost avoided;
+   * when RAG ran it is the probe overhead added on top of the RAG-first path.
+   */
+  latencyDeltaMs: number;
+}
+
+/**
  * A pointer the chat layer uses to back-fill RAG hallucinationRate / grounded
  * onto a live comparison_case row after the agent's response is available.
  *
@@ -169,6 +206,7 @@ export interface ContextPacket {
     compressionRatio: number;
     budgetUtilization: Record<string, number>;
     stageTimings: Record<string, number>;
+    claimkitFirstMetrics: ClaimKitFirstMetrics;
     claimkit: {
       enabled: boolean;
       available: boolean;

--- a/tests/unit/context-engine/context-packet-retrieval.test.ts
+++ b/tests/unit/context-engine/context-packet-retrieval.test.ts
@@ -42,6 +42,10 @@ const mockEnv = {
   CLAIMKIT_GAP_FILL_THRESHOLD: 0.3,
   CLAIMKIT_GAP_FILL_MAX_QUERIES: 2,
   CLAIMKIT_LIVE_GROUNDING_RATE: 0,
+  CLAIMKIT_FIRST_ROUTING: false,
+  CLAIMKIT_HIGH_CONFIDENCE_THRESHOLD: 0.8,
+  CLAIMKIT_LOW_CONFIDENCE_THRESHOLD: 0.5,
+  CLAIMKIT_FIRST_PROBE_TIMEOUT_MS: 500,
   KNOWLEDGE_GRAPH_QUERY_ENABLED: true,
   KNOWLEDGE_GRAPH_DOC_LIMIT: 5,
   KNOWLEDGE_GRAPH_COMMUNITY_LIMIT: 10,
@@ -161,6 +165,10 @@ describe("assembleContextPacket retrieval and context sections", () => {
     vi.clearAllMocks();
     mockEnv.RAG_INCLUDE_LOCAL_SOURCES = true;
     mockEnv.CLAIMKIT_ENABLED = false;
+    mockEnv.CLAIMKIT_FIRST_ROUTING = false;
+    mockEnv.CLAIMKIT_HIGH_CONFIDENCE_THRESHOLD = 0.8;
+    mockEnv.CLAIMKIT_LOW_CONFIDENCE_THRESHOLD = 0.5;
+    mockEnv.CLAIMKIT_FIRST_PROBE_TIMEOUT_MS = 500;
     mockClaimKitAdapter.isAvailable.mockReturnValue(false);
     mockClaimKitAdapter.initialize.mockResolvedValue(false);
     mockClaimKitAdapter.getInitError.mockReturnValue(null);
@@ -304,5 +312,105 @@ describe("assembleContextPacket retrieval and context sections", () => {
     expect(docs.content).not.toContain("hidden");
     expect(mockCodebaseSearch).not.toHaveBeenCalled();
     expect(packet.diagnostics.documentsRetrieved).toBe(1);
+  });
+
+  function ckResult(
+    confidence: number,
+    answerability: string,
+    claimCount = 3,
+  ) {
+    return {
+      answer: "ClaimKit structured answer.",
+      citations: [{ claimId: "c1", sourceId: "s1", text: "evidence text" }],
+      confidence,
+      contradictions: [],
+      missingEvidence: [],
+      answerability,
+      metadata: {
+        sourceIds: ["s1", "s2"],
+        claimCount,
+        processingTimeMs: 12,
+        retrievalScore: 0.9,
+      },
+    };
+  }
+
+  it("skips RAG retrieval when the ClaimKit-first probe is high-confidence", async () => {
+    mockEnv.CLAIMKIT_ENABLED = true;
+    mockEnv.CLAIMKIT_FIRST_ROUTING = true;
+    mockClaimKitAdapter.isAvailable.mockReturnValue(true);
+    mockClaimKitAdapter.initialize.mockResolvedValue(true);
+    mockClaimKitAdapter.query.mockResolvedValue(ckResult(0.95, "answerable"));
+    mockKnowledgeSearch.mockReturnValue([
+      knowledgeHit("k1", "manual", "Runbook", "Should not be retrieved"),
+    ]);
+
+    const { assembleContextPacket } = await loadContextPacket();
+    const packet = await assembleContextPacket({
+      mode: "engineering",
+      query: "what is the deploy process",
+      sessionMessages: [],
+      providerMaxTokens: 8192,
+      toolTokens: 1024,
+    });
+
+    expect(packet.diagnostics.claimkitFirstMetrics.strategy).toBe("claimkit_first_skip_rag");
+    expect(packet.diagnostics.claimkitFirstMetrics.ragSkipped).toBe(true);
+    expect(packet.diagnostics.documentsRetrieved).toBe(0);
+    // RAG stores must never be touched on the skip path.
+    expect(mockKnowledgeSearch).not.toHaveBeenCalled();
+    expect(mockCodebaseSearch).not.toHaveBeenCalled();
+    // The probe answer is reused — ClaimKit is queried exactly once.
+    expect(mockClaimKitAdapter.query).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs RAG retrieval when the ClaimKit-first probe is medium-confidence (parallel path)", async () => {
+    mockEnv.CLAIMKIT_ENABLED = true;
+    mockEnv.CLAIMKIT_FIRST_ROUTING = true;
+    mockClaimKitAdapter.isAvailable.mockReturnValue(true);
+    mockClaimKitAdapter.initialize.mockResolvedValue(true);
+    mockClaimKitAdapter.query.mockResolvedValue(ckResult(0.6, "partially-answerable"));
+    mockKnowledgeSearch.mockReturnValue([
+      knowledgeHit("k1", "manual", "Runbook", "Auth runbook content"),
+    ]);
+
+    const { assembleContextPacket } = await loadContextPacket();
+    const packet = await assembleContextPacket({
+      mode: "engineering",
+      query: "auth runbook",
+      sessionMessages: [],
+      providerMaxTokens: 8192,
+      toolTokens: 1024,
+    });
+
+    expect(packet.diagnostics.claimkitFirstMetrics.strategy).toBe("claimkit_first_parallel");
+    expect(packet.diagnostics.claimkitFirstMetrics.ragSkipped).toBe(false);
+    expect(packet.diagnostics.documentsRetrieved).toBeGreaterThan(0);
+    expect(mockKnowledgeSearch).toHaveBeenCalled();
+  });
+
+  it("falls back to rag_first when the ClaimKit-first probe throws", async () => {
+    mockEnv.CLAIMKIT_ENABLED = true;
+    mockEnv.CLAIMKIT_FIRST_ROUTING = true;
+    mockClaimKitAdapter.isAvailable.mockReturnValue(true);
+    mockClaimKitAdapter.initialize.mockResolvedValue(true);
+    mockClaimKitAdapter.query.mockRejectedValue(new Error("probe boom"));
+    mockKnowledgeSearch.mockReturnValue([
+      knowledgeHit("k1", "manual", "Runbook", "Auth runbook content"),
+    ]);
+
+    const { assembleContextPacket } = await loadContextPacket();
+    const packet = await assembleContextPacket({
+      mode: "engineering",
+      query: "auth runbook",
+      sessionMessages: [],
+      providerMaxTokens: 8192,
+      toolTokens: 1024,
+    });
+
+    expect(packet.diagnostics.claimkitFirstMetrics.strategy).toBe("rag_first");
+    expect(packet.diagnostics.claimkitFirstMetrics.ragSkipped).toBe(false);
+    expect(packet.diagnostics.documentsRetrieved).toBeGreaterThan(0);
+    expect(mockKnowledgeSearch).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #229

_Generated by AiRemoteCoder autonomous agent._