### PR TITLE
[AI] [SPRINT-6] Implement ClaimKit-first retrieval with confidence-based RAG fallback

### DIFF
--- a/src/comparison-runs/database.ts
+++ b/src/comparison-runs/database.ts
@@ -112,14 +112,27 @@ class ComparisonRunDatabase {
       { col: "confidence_trace", def: "TEXT" },
       // ClaimKit-first routing strategy (issue #229): which of the three
       // ClaimKit-first paths (or rag_first) was chosen for this query. Lets
-      // the dashboard measure RAG-skip rate and per-path latency.
+      // the dashboard measure RAG-skip rate and per-path latency. Additive &
+      // nullable, so rolling the application code back is safe — older INSERTs
+      // simply omit the column and SQLite stores NULL. Rolling the schema
+      // forward is idempotent (the ALTER below no-ops once the column exists).
       { col: "routing_strategy", def: "TEXT" },
     ];
     for (const { col, def } of migrations) {
       try {
         this.db.exec(`ALTER TABLE comparison_cases ADD COLUMN ${col} ${def}`);
-      } catch {
-        // Column already exists — skip
+      } catch (err) {
+        // Re-running on an already-migrated DB throws "duplicate column name",
+        // which is expected and safe to ignore. Any OTHER failure (locked DB,
+        // disk error, corruption) would leave the column missing while
+        // createRun still binds it positionally — surface it loudly here
+        // rather than silently proceeding into broken INSERTs later.
+        const msg = err instanceof Error ? err.message : String(err);
+        if (!/duplicate column name/i.test(msg)) {
+          throw new Error(
+            `[ComparisonRunDatabase] migration failed adding column "${col}": ${msg}`,
+          );
+        }
       }
     }
 

--- a/src/context-engine/context-packet.ts
+++ b/src/context-engine/context-packet.ts
@@ -46,12 +46,6 @@ export interface RoutingDecision {
   routingReason: string;
 }
 
-// Most-recently-observed RAG retrieval latency (ms). Used to estimate the
-// time saved when a high-confidence ClaimKit probe lets us skip RAG (issue
-// #229). Seeded to 0 so the first-ever skip reports no estimated savings
-// rather than a fabricated number.
-let recentRagRetrievalMs = 0;
-
 const INSUFFICIENT_EVIDENCE_PATTERNS = [
   "insufficient evidence to answer this question",
   "the available evidence is insufficient",
@@ -337,12 +331,16 @@ export async function assembleContextPacket(
     }),
   ]);
 
-  // Estimate the latency change vs. the old RAG-first path (negative = faster).
-  // When RAG was skipped, the savings is the most-recently-observed RAG
-  // retrieval cost; when RAG ran, the probe added its own latency on top.
-  const ragRetrievalMs = stageTimings.retrieveStoresMs ?? 0;
-  if (!ragSkipped) recentRagRetrievalMs = ragRetrievalMs;
-  const latencyDeltaMs = ragSkipped ? -recentRagRetrievalMs : probeLatencyMs;
+  // Per-request latency delta vs. the old RAG-first path (issue #229
+  // follow-up). This is computed ONLY from this request's own timings — it
+  // never reads another request's RAG latency, so a skip on request B can't
+  // report request A's (stale, unrelated) RAG cost.
+  //   - RAG ran: the only added cost vs. the old path is the probe.
+  //   - RAG skipped: RAG did not run this request, so there is no avoided-RAG
+  //     cost measurable inline. The dashboard derives skip savings in
+  //     aggregate by comparing rag_time_ms across skip vs. non-skip cohorts
+  //     (routing_strategy is persisted on each comparison_case row).
+  const latencyDeltaMs = ragSkipped ? 0 : probeLatencyMs;
 
   const historyTokens = selectedMessages.reduce((sum, s) => sum + s.tokens, 0);
 
@@ -431,41 +429,67 @@ export async function assembleContextPacket(
       }
     }
     stageTimings.claimkitSeedMs = Date.now() - seedStart;
-    onProgress?.("Querying knowledge graph...");
-    const ckStart = Date.now();
-    try {
-      claimKitResult = await withAbortableTimeout(
-        (signal) => claimKitAdapter.query(query, { signal }),
-        env.CLAIMKIT_QUERY_TIMEOUT_MS,
-        null,
+
+    // ClaimKit-first parallel/fallback: the pre-flight probe already queried
+    // ClaimKit against the same claim store. Re-querying only returns
+    // something new when seeding was AWAITED — that is the one case where the
+    // store changed between the probe and now (freshly ingested RAG-derived
+    // claims). When seeding is fire-and-forget (CLAIMKIT_AWAIT_SEED=false, the
+    // default) a second query would race the un-awaited ingest and reproduce
+    // the probe's result, so we reuse the probe and skip the redundant call.
+    // A null probe means routing fell back to rag_first (probe disabled or
+    // threw); there we have no probe result and must run a real query.
+    const canReuseProbe =
+      ckProbe !== null &&
+      routingStrategy !== "rag_first" &&
+      !env.CLAIMKIT_AWAIT_SEED;
+    if (canReuseProbe) {
+      const reused = ckProbe!;
+      claimKitResult = reused;
+      ckMs = probeLatencyMs;
+      stageTimings.claimkitQueryMs = ckMs;
+      ckStatus = reused.metadata.claimCount === 0 ? "no_claims" : "answered";
+      const symbol = reused.answerability === "answerable" ? "✅" : reused.answerability === "partially-answerable" ? "⚠️" : "❌";
+      console.log(
+        `[ClaimKit] ${symbol} ${reused.answerability} | confidence=${(reused.confidence * 100).toFixed(0)}% | claims=${reused.metadata.claimCount} | sources=${reused.metadata.sourceIds.length} | score=${reused.metadata.retrievalScore.toFixed(2)} | ${ckMs}ms (probe reused, ${routingStrategy})`,
       );
-      ckMs = Date.now() - ckStart;
-      stageTimings.claimkitQueryMs = ckMs;
-      if (!claimKitResult) {
-        ckStatus = "timeout";
-        console.warn(`[ClaimKit] Query timed out after ${ckMs}ms (limit: ${env.CLAIMKIT_QUERY_TIMEOUT_MS}ms)`);
-      } else {
-        ckStatus = claimKitResult.metadata.claimCount === 0 ? "no_claims" : "answered";
-        const symbol = claimKitResult.answerability === "answerable" ? "✅" : claimKitResult.answerability === "partially-answerable" ? "⚠️" : "❌";
-        console.log(
-          `[ClaimKit] ${symbol} ${claimKitResult.answerability} | confidence=${(claimKitResult.confidence * 100).toFixed(0)}% | claims=${claimKitResult.metadata.claimCount} | sources=${claimKitResult.metadata.sourceIds.length} | score=${claimKitResult.metadata.retrievalScore.toFixed(2)} | ${ckMs}ms`,
+    } else {
+      onProgress?.("Querying knowledge graph...");
+      const ckStart = Date.now();
+      try {
+        claimKitResult = await withAbortableTimeout(
+          (signal) => claimKitAdapter.query(query, { signal }),
+          env.CLAIMKIT_QUERY_TIMEOUT_MS,
+          null,
         );
-        if (claimKitResult.confidence < 0.1) {
+        ckMs = Date.now() - ckStart;
+        stageTimings.claimkitQueryMs = ckMs;
+        if (!claimKitResult) {
+          ckStatus = "timeout";
+          console.warn(`[ClaimKit] Query timed out after ${ckMs}ms (limit: ${env.CLAIMKIT_QUERY_TIMEOUT_MS}ms)`);
+        } else {
+          ckStatus = claimKitResult.metadata.claimCount === 0 ? "no_claims" : "answered";
+          const symbol = claimKitResult.answerability === "answerable" ? "✅" : claimKitResult.answerability === "partially-answerable" ? "⚠️" : "❌";
           console.log(
-            `[ClaimKit:DEBUG] query="${query.substring(0, 120)}" | ` +
-            `sources=${claimKitResult.metadata.sourceIds.length} | ` +
-            `retrievalScore=${claimKitResult.metadata.retrievalScore.toFixed(3)} | ` +
-            `answer=${claimKitResult.answer.substring(0, 200)} | ` +
-            `missingEvidence=[${claimKitResult.missingEvidence.slice(0, 5).join(", ")}] | ` +
-            `citations=[${claimKitResult.citations.slice(0, 3).map(c => c.sourceId).join(", ")}]`,
+            `[ClaimKit] ${symbol} ${claimKitResult.answerability} | confidence=${(claimKitResult.confidence * 100).toFixed(0)}% | claims=${claimKitResult.metadata.claimCount} | sources=${claimKitResult.metadata.sourceIds.length} | score=${claimKitResult.metadata.retrievalScore.toFixed(2)} | ${ckMs}ms`,
           );
+          if (claimKitResult.confidence < 0.1) {
+            console.log(
+              `[ClaimKit:DEBUG] query="${query.substring(0, 120)}" | ` +
+              `sources=${claimKitResult.metadata.sourceIds.length} | ` +
+              `retrievalScore=${claimKitResult.metadata.retrievalScore.toFixed(3)} | ` +
+              `answer=${claimKitResult.answer.substring(0, 200)} | ` +
+              `missingEvidence=[${claimKitResult.missingEvidence.slice(0, 5).join(", ")}] | ` +
+              `citations=[${claimKitResult.citations.slice(0, 3).map(c => c.sourceId).join(", ")}]`,
+            );
+          }
         }
+      } catch (err) {
+        ckMs = Date.now() - ckStart;
+        ckStatus = "error";
+        stageTimings.claimkitQueryMs = ckMs;
+        console.warn("[ClaimKit] Query failed:", err);
       }
-    } catch (err) {
-      ckMs = Date.now() - ckStart;
-      ckStatus = "error";
-      stageTimings.claimkitQueryMs = ckMs;
-      console.warn("[ClaimKit] Query failed:", err);
     }
   }
 

--- a/src/context-engine/types.ts
+++ b/src/context-engine/types.ts
@@ -156,9 +156,12 @@ export interface ClaimKitFirstMetrics {
   /** True when RAG retrieval was skipped because the probe was high-confidence. */
   ragSkipped: boolean;
   /**
-   * Estimated latency change vs. the old RAG-first path. Negative = faster.
-   * When RAG was skipped this is the (estimated) RAG retrieval cost avoided;
-   * when RAG ran it is the probe overhead added on top of the RAG-first path.
+   * Per-request latency delta vs. the old RAG-first path, computed only from
+   * this request's own timings (never another request's RAG latency).
+   * When RAG ran this is the probe overhead added on top of the RAG-first
+   * path. When RAG was skipped it is 0 — no avoided-RAG cost is measurable
+   * inline, so the dashboard derives skip savings in aggregate by comparing
+   * rag_time_ms across skip vs. non-skip cohorts (keyed on routing_strategy).
    */
   latencyDeltaMs: number;
 }

--- a/tests/unit/comparison-runs/diagnostic-fields.test.ts
+++ b/tests/unit/comparison-runs/diagnostic-fields.test.ts
@@ -61,6 +61,54 @@ describe("ComparisonRunDatabase — diagnostic fields", () => {
       expect(c.winner_reason).toBe("low_confidence");
     });
 
+    it("persists and reads back the ClaimKit-first routing_strategy", () => {
+      const run = db.createRun({
+        source: "live",
+        description: "routing strategy persistence",
+        cases: [
+          {
+            query: "what is the deploy process",
+            category: "direct_fact",
+            overallWinner: "claimkit",
+            winnerReason: "high_confidence",
+            rag: { contextTokens: 0, sections: 0, processingTimeMs: 4 },
+            claimkit: {
+              confidence: 0.95,
+              answerability: "answerable",
+              claimCount: 3,
+              processingTimeMs: 40,
+              contradictions: 0,
+            },
+            routingStrategy: "claimkit_first_skip_rag",
+          },
+        ],
+      });
+
+      expect(run.cases[0].routing_strategy).toBe("claimkit_first_skip_rag");
+
+      // Survives a fresh read from disk (not just the in-memory create result).
+      const reloaded = db.getRun(run.id);
+      expect(reloaded!.cases[0].routing_strategy).toBe("claimkit_first_skip_rag");
+    });
+
+    it("stores null routing_strategy when the case omits it", () => {
+      const run = db.createRun({
+        source: "live",
+        cases: [
+          {
+            query: "test",
+            category: "direct_fact",
+            overallWinner: "rag",
+            winnerReason: "ck_unavailable",
+            rag: { contextTokens: 100, sections: 1, processingTimeMs: 10 },
+            claimkit: null,
+          },
+        ],
+      });
+
+      expect(run.cases[0].routing_strategy).toBeNull();
+    });
+
     it("stores nulls for optional diagnostic fields when claimkit is null", () => {
       const run = db.createRun({
         source: "live",

--- a/tests/unit/context-engine/context-packet-retrieval.test.ts
+++ b/tests/unit/context-engine/context-packet-retrieval.test.ts
@@ -166,6 +166,7 @@ describe("assembleContextPacket retrieval and context sections", () => {
     mockEnv.RAG_INCLUDE_LOCAL_SOURCES = true;
     mockEnv.CLAIMKIT_ENABLED = false;
     mockEnv.CLAIMKIT_FIRST_ROUTING = false;
+    mockEnv.CLAIMKIT_AWAIT_SEED = false;
     mockEnv.CLAIMKIT_HIGH_CONFIDENCE_THRESHOLD = 0.8;
     mockEnv.CLAIMKIT_LOW_CONFIDENCE_THRESHOLD = 0.5;
     mockEnv.CLAIMKIT_FIRST_PROBE_TIMEOUT_MS = 500;
@@ -387,6 +388,66 @@ describe("assembleContextPacket retrieval and context sections", () => {
     expect(packet.diagnostics.claimkitFirstMetrics.ragSkipped).toBe(false);
     expect(packet.diagnostics.documentsRetrieved).toBeGreaterThan(0);
     expect(mockKnowledgeSearch).toHaveBeenCalled();
+  });
+
+  it("falls back to full RAG when the ClaimKit-first probe is low-confidence", async () => {
+    mockEnv.CLAIMKIT_ENABLED = true;
+    mockEnv.CLAIMKIT_FIRST_ROUTING = true;
+    mockEnv.CLAIMKIT_AWAIT_SEED = false;
+    mockClaimKitAdapter.isAvailable.mockReturnValue(true);
+    mockClaimKitAdapter.initialize.mockResolvedValue(true);
+    // Low confidence + answerable → claimkit_first_fallback: RAG must run and
+    // the probe result is reused (no redundant second query when seed is not
+    // awaited).
+    mockClaimKitAdapter.query.mockResolvedValue(ckResult(0.3, "answerable"));
+    mockKnowledgeSearch.mockReturnValue([
+      knowledgeHit("k1", "manual", "Runbook", "Auth runbook content"),
+    ]);
+
+    const { assembleContextPacket } = await loadContextPacket();
+    const packet = await assembleContextPacket({
+      mode: "engineering",
+      query: "auth runbook",
+      sessionMessages: [],
+      providerMaxTokens: 8192,
+      toolTokens: 1024,
+    });
+
+    expect(packet.diagnostics.claimkitFirstMetrics.strategy).toBe("claimkit_first_fallback");
+    expect(packet.diagnostics.claimkitFirstMetrics.ragSkipped).toBe(false);
+    expect(packet.diagnostics.claimkitFirstMetrics.latencyDeltaMs).toBeGreaterThanOrEqual(0);
+    expect(packet.diagnostics.documentsRetrieved).toBeGreaterThan(0);
+    expect(mockKnowledgeSearch).toHaveBeenCalled();
+    // Probe reused: ClaimKit queried exactly once even though RAG also ran.
+    expect(mockClaimKitAdapter.query).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-queries ClaimKit after seeding when CLAIMKIT_AWAIT_SEED is enabled", async () => {
+    mockEnv.CLAIMKIT_ENABLED = true;
+    mockEnv.CLAIMKIT_FIRST_ROUTING = true;
+    mockEnv.CLAIMKIT_AWAIT_SEED = true;
+    mockClaimKitAdapter.isAvailable.mockReturnValue(true);
+    mockClaimKitAdapter.initialize.mockResolvedValue(true);
+    mockClaimKitAdapter.query.mockResolvedValue(ckResult(0.6, "answerable"));
+    mockKnowledgeSearch.mockReturnValue([
+      knowledgeHit("k1", "manual", "Runbook", "Auth runbook content"),
+    ]);
+
+    const { assembleContextPacket } = await loadContextPacket();
+    const packet = await assembleContextPacket({
+      mode: "engineering",
+      query: "auth runbook",
+      sessionMessages: [],
+      providerMaxTokens: 8192,
+      toolTokens: 1024,
+    });
+
+    expect(packet.diagnostics.claimkitFirstMetrics.strategy).toBe("claimkit_first_parallel");
+    // Awaited seeding can change the claim store between probe and query, so a
+    // fresh full query runs on top of the probe (probe + full = 2 calls).
+    expect(mockClaimKitAdapter.query).toHaveBeenCalledTimes(2);
+
+    mockEnv.CLAIMKIT_AWAIT_SEED = false;
   });
 
   it("falls back to rag_first when the ClaimKit-first probe throws", async () => {


### PR DESCRIPTION
Closes #229

_Generated by AiRemoteCoder autonomous agent._