### PR TITLE
[AI] [SPRINT-1] Add cost-aware retrieval cascade to context-packet — escalate through ClaimKit, teacher LLM verification, web research before falling back to full RAG

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -401,6 +401,31 @@ const envSchema = z.object({
   // probes still degrade into "rag_first" rather than adding latency.
   CLAIMKIT_FIRST_PROBE_TIMEOUT_MS: z.coerce.number().default(3000),
 
+  // ── Cost-aware retrieval cascade (issue #245) ────────────────────────
+  // When the ClaimKit-first probe lands in the medium-confidence band, the
+  // cascade escalates through cheaper verification — a teacher-LLM check, then
+  // a web_search corroboration — before paying for full RAG retrieval. U-Mem
+  // (arXiv:2602.22406 §3.2) shows this cuts expensive retrieval calls by 40%+.
+  // Off by default: opt in once a teacher model and/or web search is configured.
+  CASCADE_ENABLED: z
+    .string()
+    .transform((s) => s === "true")
+    .default("false"),
+  // Total token budget across all cascade escalation steps. The cascade stops
+  // escalating and falls back to full RAG once this budget can't afford the
+  // next step.
+  CASCADE_BUDGET_TOKENS: z.coerce.number().default(5000),
+  // Confidence at/above which a cascade level resolves the query and full RAG
+  // is skipped.
+  CASCADE_STOP_CONFIDENCE: z.coerce.number().default(0.8),
+  // Teacher model used for the TEACHER_VERIFY step. Empty (default) lets the
+  // current provider pick its configured model.
+  CASCADE_TEACHER_MODEL: z.string().default(""),
+  // Estimated token cost charged against the budget for the teacher step.
+  CASCADE_TEACHER_COST_TOKENS: z.coerce.number().default(1000),
+  // Estimated token cost charged against the budget for the tool-research step.
+  CASCADE_TOOL_COST_TOKENS: z.coerce.number().default(2000),
+
   // Knowledge graph retrieval controls
   KNOWLEDGE_GRAPH_QUERY_ENABLED: z
     .string()

--- a/src/context-engine/context-packet.ts
+++ b/src/context-engine/context-packet.ts
@@ -21,6 +21,7 @@ import type {
   GroundingHandle,
 } from "./types";
 import { claimKitAdapter } from "./adapters/claimkit-adapter";
+import { createDefaultCascade, type CascadeResolution } from "./retrieval-cascade";
 import { rewriteQuerySafe, boostEntityMatches, mergeAndDedupe } from "./query-rewriter";
 import { ingestScoredDocumentsForQuery } from "./claimkit-ingestion";
 import { saveLiveComparison } from "../comparison-runs/auto-capture";
@@ -324,7 +325,50 @@ export async function assembleContextPacket(
       `probe_answerability=${ckProbe?.answerability ?? "—"} | probe=${probeLatencyMs}ms`,
     );
   }
-  const ragSkipped = routingStrategy === "claimkit_first_skip_rag";
+  // ── Cost-aware retrieval cascade (issue #245) ────────────────────────
+  // The ClaimKit-first probe is Level 0 of the cascade. When it lands in the
+  // medium/low band (RAG would otherwise run) we escalate through cheaper
+  // verification — a teacher-LLM check, then a web_search corroboration —
+  // before paying for full RAG. A cheap resolution skips RAG entirely; a
+  // budget-exhausted or unresolved cascade falls through to full RAG (existing
+  // Level 3 behavior). The whole step is gated by CASCADE_ENABLED so the
+  // ClaimKit-first behavior is fully preserved when the cascade is off.
+  let cascadeResolution: CascadeResolution | null = null;
+  let cascadeSkippedRag = false;
+  if (
+    env.CASCADE_ENABLED &&
+    routingStrategy !== "rag_first" &&
+    routingStrategy !== "claimkit_first_skip_rag" &&
+    ckProbe !== null &&
+    (ckProbe.answerability === "answerable" || ckProbe.answerability === "partially-answerable")
+  ) {
+    try {
+      cascadeResolution = await timeStage("cascadeMs", () =>
+        createDefaultCascade().run({
+          query: retrievalQuery,
+          claimKitAnswer: ckProbe!.answer,
+          confidence: ckProbe!.confidence,
+        }),
+      );
+      cascadeSkippedRag =
+        cascadeResolution.outcome === "ck_high_confidence" ||
+        cascadeResolution.outcome === "teacher_confirmed" ||
+        cascadeResolution.outcome === "tool_confirmed";
+      console.log(
+        `[ContextPacket] cascade ${cascadeResolution.level} | outcome=${cascadeResolution.outcome} | ` +
+        `tokensUsed=${cascadeResolution.tokensUsed} | confidence=${(cascadeResolution.confidence * 100).toFixed(0)}% | ` +
+        `rag_skipped=${cascadeSkippedRag}`,
+      );
+    } catch (err) {
+      cascadeResolution = null;
+      console.warn(
+        "[ContextPacket] retrieval cascade failed:",
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+
+  const ragSkipped = routingStrategy === "claimkit_first_skip_rag" || cascadeSkippedRag;
 
   const baseSystemPrompt = getSystemPrompt(mode, query, "engine");
   const systemTokens = estimateTokens(baseSystemPrompt);
@@ -1248,6 +1292,14 @@ export async function assembleContextPacket(
         ragSkipped,
         latencyDeltaMs,
       },
+      cascade: cascadeResolution
+        ? {
+            level: cascadeResolution.level,
+            tokensUsed: cascadeResolution.tokensUsed,
+            confidence: cascadeResolution.confidence,
+            outcome: cascadeResolution.outcome,
+          }
+        : null,
       queryRewriteMetrics: {
         enabled: env.QUERY_REWRITER_ENABLED,
         latencyMs: rewritten.rewriteLatencyMs,

--- a/src/context-engine/retrieval-cascade.ts
+++ b/src/context-engine/retrieval-cascade.ts
@@ -1,0 +1,334 @@
+// Cost-aware retrieval cascade (issue #245).
+//
+// The context packet historically had a binary fallback: a ClaimKit-first
+// probe answered directly when confident, otherwise it paid the full cost of
+// RAG retrieval. U-Mem (arXiv:2602.22406, §3.2) shows agents save 40%+ of
+// expensive retrieval calls by escalating through cheaper verification steps
+// first. This module implements that escalation as four ordered levels:
+//
+//   Level 0 CLAIMKIT       — the pre-flight probe (already run by the caller).
+//   Level 1 TEACHER_VERIFY — ask a higher-tier model to confirm the ClaimKit
+//                            answer (~1k tokens).
+//   Level 2 TOOL_RESEARCH  — corroborate the answer with web_search (~2k tokens).
+//   Level 3 FULL_RAG       — the existing, most expensive fallback.
+//
+// The cascade stops as soon as a level resolves the query with confidence at
+// or above the stop threshold, or when the remaining token budget can't afford
+// the next step (in which case it falls back to full RAG). The class itself is
+// pure orchestration: the teacher verifier and tool researcher are injected so
+// the escalation logic is testable without live providers.
+
+import { env } from "../config/env";
+import { aiClient } from "../agent/opencode-client";
+import { webSearchClient } from "../integrations/web/search-client";
+import { estimateTokens } from "./budget";
+
+export enum CascadeLevel {
+  CLAIMKIT = "claimkit",
+  TEACHER_VERIFY = "teacher_verify",
+  TOOL_RESEARCH = "tool_research",
+  FULL_RAG = "full_rag",
+}
+
+export type CascadeOutcome =
+  | "ck_high_confidence"
+  | "teacher_confirmed"
+  | "tool_confirmed"
+  | "budget_exhausted"
+  | "fell_back_to_rag";
+
+/** The terminal result of one cascade run — also the shape logged for debug. */
+export interface CascadeResolution {
+  level: CascadeLevel;
+  tokensUsed: number;
+  confidence: number;
+  outcome: CascadeOutcome;
+}
+
+export interface CascadeInput {
+  /** The (rewritten) retrieval query. */
+  query: string;
+  /** The candidate answer produced by the ClaimKit probe. */
+  claimKitAnswer: string;
+  /** ClaimKit probe confidence in [0, 1]. */
+  confidence: number;
+  signal?: AbortSignal;
+}
+
+export interface TeacherVerdict {
+  confirmed: boolean;
+  /** The teacher's own confidence in the candidate answer, in [0, 1]. */
+  confidence: number;
+  tokensUsed: number;
+}
+
+export interface ToolResearchResult {
+  resolved: boolean;
+  /** How strongly the retrieved evidence supports the candidate answer. */
+  confidence: number;
+  evidence: string;
+  tokensUsed: number;
+}
+
+export interface TeacherVerifier {
+  verify(input: CascadeInput): Promise<TeacherVerdict>;
+}
+
+export interface ToolResearcher {
+  research(input: CascadeInput): Promise<ToolResearchResult>;
+}
+
+export interface RetrievalCascadeConfig {
+  /** Total token budget across all escalation steps. */
+  budgetTokens: number;
+  /** Confidence at/above which the cascade stops and skips full RAG. */
+  stopConfidence: number;
+  /** Lower bound of the "medium confidence" band that triggers TEACHER_VERIFY. */
+  lowThreshold: number;
+  /** Estimated cost of the teacher step, charged against the budget. */
+  teacherCostTokens: number;
+  /** Estimated cost of the tool-research step, charged against the budget. */
+  toolCostTokens: number;
+}
+
+function clamp01(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(1, n));
+}
+
+export class RetrievalCascade {
+  constructor(
+    private readonly teacher: TeacherVerifier,
+    private readonly researcher: ToolResearcher,
+    private readonly config: RetrievalCascadeConfig,
+  ) {}
+
+  /**
+   * Escalate from the ClaimKit probe result through teacher verification and
+   * tool research, stopping at the first level that resolves the query with
+   * sufficient confidence (or when the budget can't afford the next step).
+   */
+  async run(input: CascadeInput): Promise<CascadeResolution> {
+    const conf = clamp01(input.confidence);
+    let tokensUsed = 0;
+
+    // Level 0 — the ClaimKit probe already answered. High confidence resolves
+    // immediately; no escalation cost.
+    if (conf >= this.config.stopConfidence) {
+      return {
+        level: CascadeLevel.CLAIMKIT,
+        tokensUsed,
+        confidence: conf,
+        outcome: "ck_high_confidence",
+      };
+    }
+
+    const isMedium = conf >= this.config.lowThreshold;
+
+    // Level 1 — TEACHER_VERIFY. Only attempted for medium-confidence probes:
+    // a confident-enough answer that just needs a second opinion. Below the
+    // medium band the answer is too weak to be worth a teacher pass, so we go
+    // straight to tool research.
+    if (isMedium) {
+      if (tokensUsed + this.config.teacherCostTokens > this.config.budgetTokens) {
+        return {
+          level: CascadeLevel.FULL_RAG,
+          tokensUsed,
+          confidence: conf,
+          outcome: "budget_exhausted",
+        };
+      }
+      const verdict = await this.teacher.verify(input);
+      tokensUsed += Math.max(0, verdict.tokensUsed);
+      if (verdict.confirmed && clamp01(verdict.confidence) >= this.config.stopConfidence) {
+        return {
+          level: CascadeLevel.TEACHER_VERIFY,
+          tokensUsed,
+          confidence: clamp01(verdict.confidence),
+          outcome: "teacher_confirmed",
+        };
+      }
+      // Teacher rejected (or wasn't confident enough) → escalate to research.
+    }
+
+    // Level 2 — TOOL_RESEARCH. Reached when the teacher rejected the answer or
+    // the probe was below the medium band.
+    if (tokensUsed + this.config.toolCostTokens > this.config.budgetTokens) {
+      return {
+        level: CascadeLevel.FULL_RAG,
+        tokensUsed,
+        confidence: conf,
+        outcome: "budget_exhausted",
+      };
+    }
+    const research = await this.researcher.research(input);
+    tokensUsed += Math.max(0, research.tokensUsed);
+    if (research.resolved && clamp01(research.confidence) >= this.config.stopConfidence) {
+      return {
+        level: CascadeLevel.TOOL_RESEARCH,
+        tokensUsed,
+        confidence: clamp01(research.confidence),
+        outcome: "tool_confirmed",
+      };
+    }
+
+    // Level 3 — FULL_RAG fallback. Nothing cheaper resolved the query.
+    return {
+      level: CascadeLevel.FULL_RAG,
+      tokensUsed,
+      confidence: Math.max(conf, clamp01(research.confidence)),
+      outcome: "fell_back_to_rag",
+    };
+  }
+}
+
+/** Tokens worth corroborating: drop stopwords/short noise. */
+function keywordTokens(text: string): string[] {
+  return [
+    ...new Set(
+      text
+        .toLowerCase()
+        .replace(/[^a-z0-9_\s-]/g, " ")
+        .split(/\s+/)
+        .filter((t) => t.length > 3),
+    ),
+  ];
+}
+
+/** Parse the teacher model's verdict, tolerating prose around the JSON. */
+export function parseTeacherVerdict(raw: string): { confirmed: boolean; confidence: number } {
+  if (!raw) return { confirmed: false, confidence: 0 };
+  const jsonMatch = raw.match(/\{[\s\S]*\}/);
+  if (jsonMatch) {
+    try {
+      const obj = JSON.parse(jsonMatch[0]) as { verdict?: unknown; confidence?: unknown };
+      const verdict = String(obj.verdict ?? "").toLowerCase();
+      const confidence = clamp01(Number(obj.confidence));
+      if (verdict === "confirm") return { confirmed: true, confidence };
+      if (verdict === "reject") return { confirmed: false, confidence };
+    } catch {
+      // fall through to the keyword heuristic
+    }
+  }
+  const lowered = raw.toLowerCase();
+  if (lowered.includes("confirm")) return { confirmed: true, confidence: 0.8 };
+  return { confirmed: false, confidence: 0 };
+}
+
+/**
+ * Score how strongly web evidence corroborates the candidate answer by keyword
+ * overlap. When there is no candidate answer to corroborate, fall back to a
+ * coverage signal based on how many results came back.
+ */
+export function scoreEvidenceSupport(
+  answer: string,
+  evidence: string,
+  resultCount: number,
+): number {
+  if (!evidence) return 0;
+  const answerTokens = keywordTokens(answer);
+  if (answerTokens.length === 0) {
+    return resultCount > 0 ? Math.min(0.8, 0.4 + resultCount * 0.1) : 0;
+  }
+  const lowered = evidence.toLowerCase();
+  const matched = answerTokens.filter((t) => lowered.includes(t)).length;
+  return clamp01(matched / answerTokens.length);
+}
+
+/** Default teacher verifier — a single JSON-mode chat call to a higher tier. */
+export function createDefaultTeacherVerifier(): TeacherVerifier {
+  return {
+    async verify({ query, claimKitAnswer, signal }) {
+      const messages = [
+        {
+          role: "system" as const,
+          content:
+            "You are a strict fact-checker. Decide whether the candidate answer " +
+            "correctly and sufficiently answers the question. Respond ONLY with " +
+            'compact JSON: {"verdict":"confirm"|"reject","confidence":<0..1>}.',
+        },
+        {
+          role: "user" as const,
+          content:
+            `Question:\n${query}\n\n` +
+            `Candidate answer:\n${claimKitAnswer || "(no answer provided)"}\n\n` +
+            "Does the candidate answer correctly and sufficiently answer the question?",
+        },
+      ];
+      try {
+        const resp = await aiClient.chat({
+          messages,
+          model: env.CASCADE_TEACHER_MODEL || undefined,
+          temperature: 0,
+          jsonMode: true,
+          signal,
+        });
+        const parsed = parseTeacherVerdict(resp.content);
+        const tokensUsed =
+          resp.usage?.totalTokens ??
+          estimateTokens(messages.map((m) => m.content).join("\n")) +
+            estimateTokens(resp.content || "");
+        return { confirmed: parsed.confirmed, confidence: parsed.confidence, tokensUsed };
+      } catch (err) {
+        console.warn(
+          "[ContextPacket] cascade teacher verify failed:",
+          err instanceof Error ? err.message : err,
+        );
+        return { confirmed: false, confidence: 0, tokensUsed: 0 };
+      }
+    },
+  };
+}
+
+/** Default tool researcher — corroborates the answer via web_search. */
+export function createDefaultToolResearcher(): ToolResearcher {
+  return {
+    async research({ query, claimKitAnswer }) {
+      if (!webSearchClient.isConfigured()) {
+        return { resolved: false, confidence: 0, evidence: "", tokensUsed: 0 };
+      }
+      try {
+        const res = await webSearchClient.search(query, 5, {
+          includeAnswer: true,
+          searchDepth: "basic",
+        });
+        const evidenceParts = [res.answer ?? "", ...res.results.map((r) => r.snippet)].filter(
+          Boolean,
+        );
+        const evidence = evidenceParts.join("\n");
+        const confidence = scoreEvidenceSupport(claimKitAnswer, evidence, res.results.length);
+        return {
+          resolved: confidence > 0,
+          confidence,
+          evidence: evidence.slice(0, 4000),
+          tokensUsed: estimateTokens(evidence),
+        };
+      } catch (err) {
+        console.warn(
+          "[ContextPacket] cascade tool research failed:",
+          err instanceof Error ? err.message : err,
+        );
+        return { resolved: false, confidence: 0, evidence: "", tokensUsed: 0 };
+      }
+    },
+  };
+}
+
+/** Build a cascade wired to the real teacher/researcher, configured from env. */
+export function createDefaultCascade(
+  overrides?: Partial<RetrievalCascadeConfig>,
+): RetrievalCascade {
+  const config: RetrievalCascadeConfig = {
+    budgetTokens: env.CASCADE_BUDGET_TOKENS,
+    stopConfidence: env.CASCADE_STOP_CONFIDENCE,
+    lowThreshold: env.CLAIMKIT_LOW_CONFIDENCE_THRESHOLD,
+    teacherCostTokens: env.CASCADE_TEACHER_COST_TOKENS,
+    toolCostTokens: env.CASCADE_TOOL_COST_TOKENS,
+    ...overrides,
+  };
+  return new RetrievalCascade(
+    createDefaultTeacherVerifier(),
+    createDefaultToolResearcher(),
+    config,
+  );
+}

--- a/src/context-engine/types.ts
+++ b/src/context-engine/types.ts
@@ -180,6 +180,19 @@ export interface QueryRewriteMetrics {
 }
 
 /**
+ * Resolution of the cost-aware retrieval cascade (issue #245), recorded in the
+ * packet's debug diagnostics. `level` is the escalation level that resolved the
+ * query (claimkit | teacher_verify | tool_research | full_rag); `tokensUsed` is
+ * the cumulative escalation spend; `outcome` is the terminal reason.
+ */
+export interface CascadeMetrics {
+  level: string;
+  tokensUsed: number;
+  confidence: number;
+  outcome: string;
+}
+
+/**
  * A pointer the chat layer uses to back-fill RAG hallucinationRate / grounded
  * onto a live comparison_case row after the agent's response is available.
  *
@@ -223,6 +236,13 @@ export interface ContextPacket {
     budgetUtilization: Record<string, number>;
     stageTimings: Record<string, number>;
     claimkitFirstMetrics: ClaimKitFirstMetrics;
+    /**
+     * Cost-aware retrieval cascade resolution (issue #245). Null when the
+     * cascade did not run (disabled, probe high-confidence/unanswerable, or
+     * rag_first). Records which escalation level resolved the query, the tokens
+     * the escalation spent, the resolving confidence, and the outcome.
+     */
+    cascade: CascadeMetrics | null;
     queryRewriteMetrics: QueryRewriteMetrics;
     claimkit: {
       enabled: boolean;

--- a/tests/unit/context-engine/context-packet-retrieval.test.ts
+++ b/tests/unit/context-engine/context-packet-retrieval.test.ts
@@ -32,6 +32,7 @@ const mockRecentReflections = vi.fn();
 const mockSearchSessions = vi.fn();
 const mockBuildEntityClaimsSection = vi.fn();
 const mockSaveLiveComparison = vi.fn();
+const mockCascadeRun = vi.fn();
 
 const mockEnv = {
   AI_PROVIDER: "test",
@@ -50,6 +51,12 @@ const mockEnv = {
   CLAIMKIT_HIGH_CONFIDENCE_THRESHOLD: 0.8,
   CLAIMKIT_LOW_CONFIDENCE_THRESHOLD: 0.5,
   CLAIMKIT_FIRST_PROBE_TIMEOUT_MS: 500,
+  CASCADE_ENABLED: false,
+  CASCADE_BUDGET_TOKENS: 5000,
+  CASCADE_STOP_CONFIDENCE: 0.8,
+  CASCADE_TEACHER_MODEL: "",
+  CASCADE_TEACHER_COST_TOKENS: 1000,
+  CASCADE_TOOL_COST_TOKENS: 2000,
   KNOWLEDGE_GRAPH_QUERY_ENABLED: true,
   KNOWLEDGE_GRAPH_DOC_LIMIT: 5,
   KNOWLEDGE_GRAPH_COMMUNITY_LIMIT: 10,
@@ -143,6 +150,9 @@ function installMocks() {
   vi.doMock("../../../src/comparison-runs/auto-capture", () => ({
     saveLiveComparison: mockSaveLiveComparison,
   }));
+  vi.doMock("../../../src/context-engine/retrieval-cascade", () => ({
+    createDefaultCascade: () => ({ run: mockCascadeRun }),
+  }));
 }
 
 async function loadContextPacket() {
@@ -176,6 +186,10 @@ describe("assembleContextPacket retrieval and context sections", () => {
     mockEnv.CLAIMKIT_HIGH_CONFIDENCE_THRESHOLD = 0.8;
     mockEnv.CLAIMKIT_LOW_CONFIDENCE_THRESHOLD = 0.5;
     mockEnv.CLAIMKIT_FIRST_PROBE_TIMEOUT_MS = 500;
+    mockEnv.CASCADE_ENABLED = false;
+    mockEnv.CASCADE_BUDGET_TOKENS = 5000;
+    mockEnv.CASCADE_STOP_CONFIDENCE = 0.8;
+    mockCascadeRun.mockReset();
     mockEnv.QUERY_REWRITER_ENABLED = true;
     mockEnv.QUERY_REWRITE_VARIANT_COUNT = 3;
     mockClaimKitAdapter.isAvailable.mockReturnValue(false);
@@ -572,5 +586,161 @@ describe("assembleContextPacket retrieval and context sections", () => {
 
     // Primary + exactly one variant.
     expect(mockKnowledgeSearch).toHaveBeenCalledTimes(2);
+  });
+
+  // ── cost-aware retrieval cascade (issue #245) ────────────────────────────
+
+  it("does not run the cascade when CASCADE_ENABLED is false", async () => {
+    mockEnv.CLAIMKIT_ENABLED = true;
+    mockEnv.CLAIMKIT_FIRST_ROUTING = true;
+    mockEnv.CASCADE_ENABLED = false;
+    mockClaimKitAdapter.isAvailable.mockReturnValue(true);
+    mockClaimKitAdapter.initialize.mockResolvedValue(true);
+    mockClaimKitAdapter.query.mockResolvedValue(ckResult(0.6, "partially-answerable"));
+    mockKnowledgeSearch.mockReturnValue([
+      knowledgeHit("k1", "manual", "Runbook", "Auth runbook content"),
+    ]);
+
+    const { assembleContextPacket } = await loadContextPacket();
+    const packet = await assembleContextPacket({
+      mode: "engineering",
+      query: "auth runbook",
+      sessionMessages: [],
+      providerMaxTokens: 8192,
+      toolTokens: 1024,
+    });
+
+    expect(mockCascadeRun).not.toHaveBeenCalled();
+    expect(packet.diagnostics.cascade).toBeNull();
+    // Existing medium-confidence behavior is preserved: RAG still runs.
+    expect(mockKnowledgeSearch).toHaveBeenCalled();
+    expect(packet.diagnostics.documentsRetrieved).toBeGreaterThan(0);
+  });
+
+  it("skips full RAG when the cascade resolves a medium-confidence probe via the teacher", async () => {
+    mockEnv.CLAIMKIT_ENABLED = true;
+    mockEnv.CLAIMKIT_FIRST_ROUTING = true;
+    mockEnv.CASCADE_ENABLED = true;
+    mockClaimKitAdapter.isAvailable.mockReturnValue(true);
+    mockClaimKitAdapter.initialize.mockResolvedValue(true);
+    mockClaimKitAdapter.query.mockResolvedValue(ckResult(0.6, "partially-answerable"));
+    mockCascadeRun.mockResolvedValue({
+      level: "teacher_verify",
+      tokensUsed: 950,
+      confidence: 0.9,
+      outcome: "teacher_confirmed",
+    });
+    mockKnowledgeSearch.mockReturnValue([
+      knowledgeHit("k1", "manual", "Runbook", "Should not be retrieved"),
+    ]);
+
+    const { assembleContextPacket } = await loadContextPacket();
+    const packet = await assembleContextPacket({
+      mode: "engineering",
+      query: "auth runbook",
+      sessionMessages: [],
+      providerMaxTokens: 8192,
+      toolTokens: 1024,
+    });
+
+    expect(mockCascadeRun).toHaveBeenCalledTimes(1);
+    expect(mockCascadeRun).toHaveBeenCalledWith(
+      expect.objectContaining({ claimKitAnswer: "ClaimKit structured answer.", confidence: 0.6 }),
+    );
+    expect(packet.diagnostics.cascade).toEqual({
+      level: "teacher_verify",
+      tokensUsed: 950,
+      confidence: 0.9,
+      outcome: "teacher_confirmed",
+    });
+    expect(packet.diagnostics.claimkitFirstMetrics.ragSkipped).toBe(true);
+    expect(packet.diagnostics.documentsRetrieved).toBe(0);
+    // The cheap resolution means RAG stores are never touched.
+    expect(mockKnowledgeSearch).not.toHaveBeenCalled();
+    expect(mockCodebaseSearch).not.toHaveBeenCalled();
+  });
+
+  it("falls through to full RAG when the cascade cannot resolve the query cheaply", async () => {
+    mockEnv.CLAIMKIT_ENABLED = true;
+    mockEnv.CLAIMKIT_FIRST_ROUTING = true;
+    mockEnv.CASCADE_ENABLED = true;
+    mockClaimKitAdapter.isAvailable.mockReturnValue(true);
+    mockClaimKitAdapter.initialize.mockResolvedValue(true);
+    mockClaimKitAdapter.query.mockResolvedValue(ckResult(0.6, "partially-answerable"));
+    mockCascadeRun.mockResolvedValue({
+      level: "full_rag",
+      tokensUsed: 2400,
+      confidence: 0.3,
+      outcome: "fell_back_to_rag",
+    });
+    mockKnowledgeSearch.mockReturnValue([
+      knowledgeHit("k1", "manual", "Runbook", "Auth runbook content"),
+    ]);
+
+    const { assembleContextPacket } = await loadContextPacket();
+    const packet = await assembleContextPacket({
+      mode: "engineering",
+      query: "auth runbook",
+      sessionMessages: [],
+      providerMaxTokens: 8192,
+      toolTokens: 1024,
+    });
+
+    expect(mockCascadeRun).toHaveBeenCalledTimes(1);
+    expect(packet.diagnostics.cascade?.outcome).toBe("fell_back_to_rag");
+    expect(packet.diagnostics.claimkitFirstMetrics.ragSkipped).toBe(false);
+    expect(mockKnowledgeSearch).toHaveBeenCalled();
+    expect(packet.diagnostics.documentsRetrieved).toBeGreaterThan(0);
+  });
+
+  it("does not run the cascade for a high-confidence probe (skip-RAG handled at Level 0)", async () => {
+    mockEnv.CLAIMKIT_ENABLED = true;
+    mockEnv.CLAIMKIT_FIRST_ROUTING = true;
+    mockEnv.CASCADE_ENABLED = true;
+    mockClaimKitAdapter.isAvailable.mockReturnValue(true);
+    mockClaimKitAdapter.initialize.mockResolvedValue(true);
+    mockClaimKitAdapter.query.mockResolvedValue(ckResult(0.95, "answerable"));
+
+    const { assembleContextPacket } = await loadContextPacket();
+    const packet = await assembleContextPacket({
+      mode: "engineering",
+      query: "what is the deploy process",
+      sessionMessages: [],
+      providerMaxTokens: 8192,
+      toolTokens: 1024,
+    });
+
+    expect(mockCascadeRun).not.toHaveBeenCalled();
+    expect(packet.diagnostics.cascade).toBeNull();
+    expect(packet.diagnostics.claimkitFirstMetrics.strategy).toBe("claimkit_first_skip_rag");
+    expect(packet.diagnostics.documentsRetrieved).toBe(0);
+  });
+
+  it("treats a thrown cascade as a fall-through to full RAG", async () => {
+    mockEnv.CLAIMKIT_ENABLED = true;
+    mockEnv.CLAIMKIT_FIRST_ROUTING = true;
+    mockEnv.CASCADE_ENABLED = true;
+    mockClaimKitAdapter.isAvailable.mockReturnValue(true);
+    mockClaimKitAdapter.initialize.mockResolvedValue(true);
+    mockClaimKitAdapter.query.mockResolvedValue(ckResult(0.6, "partially-answerable"));
+    mockCascadeRun.mockRejectedValue(new Error("cascade boom"));
+    mockKnowledgeSearch.mockReturnValue([
+      knowledgeHit("k1", "manual", "Runbook", "Auth runbook content"),
+    ]);
+
+    const { assembleContextPacket } = await loadContextPacket();
+    const packet = await assembleContextPacket({
+      mode: "engineering",
+      query: "auth runbook",
+      sessionMessages: [],
+      providerMaxTokens: 8192,
+      toolTokens: 1024,
+    });
+
+    expect(mockCascadeRun).toHaveBeenCalledTimes(1);
+    expect(packet.diagnostics.cascade).toBeNull();
+    expect(packet.diagnostics.claimkitFirstMetrics.ragSkipped).toBe(false);
+    expect(mockKnowledgeSearch).toHaveBeenCalled();
+    expect(packet.diagnostics.documentsRetrieved).toBeGreaterThan(0);
   });
 });

--- a/tests/unit/context-engine/retrieval-cascade.test.ts
+++ b/tests/unit/context-engine/retrieval-cascade.test.ts
@@ -1,0 +1,337 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mocks for the default-wiring tests. The pure RetrievalCascade.run tests use
+// hand-written fakes and don't touch these.
+const mockChat = vi.fn();
+const mockWebIsConfigured = vi.fn();
+const mockWebSearch = vi.fn();
+
+const mockEnv = {
+  CASCADE_TEACHER_MODEL: "",
+  CASCADE_BUDGET_TOKENS: 5000,
+  CASCADE_STOP_CONFIDENCE: 0.8,
+  CASCADE_TEACHER_COST_TOKENS: 1000,
+  CASCADE_TOOL_COST_TOKENS: 2000,
+  CLAIMKIT_LOW_CONFIDENCE_THRESHOLD: 0.5,
+};
+
+function installMocks() {
+  vi.doMock("../../../src/config/env", () => ({ env: mockEnv }));
+  vi.doMock("../../../src/agent/opencode-client", () => ({
+    aiClient: { chat: mockChat },
+  }));
+  vi.doMock("../../../src/integrations/web/search-client", () => ({
+    webSearchClient: { isConfigured: mockWebIsConfigured, search: mockWebSearch },
+  }));
+}
+
+async function loadModule() {
+  vi.resetModules();
+  installMocks();
+  return import("../../../src/context-engine/retrieval-cascade");
+}
+
+const baseConfig = {
+  budgetTokens: 5000,
+  stopConfidence: 0.8,
+  lowThreshold: 0.5,
+  teacherCostTokens: 1000,
+  toolCostTokens: 2000,
+};
+
+function makeTeacher(verdict: { confirmed: boolean; confidence: number; tokensUsed?: number }) {
+  return { verify: vi.fn(async () => ({ tokensUsed: 900, ...verdict })) };
+}
+
+function makeResearcher(result: {
+  resolved: boolean;
+  confidence: number;
+  tokensUsed?: number;
+  evidence?: string;
+}) {
+  return {
+    research: vi.fn(async () => ({ evidence: "", tokensUsed: 1800, ...result })),
+  };
+}
+
+const input = { query: "what is the deploy process", claimKitAnswer: "Run deploy.sh", confidence: 0 };
+
+describe("RetrievalCascade.run", () => {
+  it("resolves at CLAIMKIT when probe confidence is already high", async () => {
+    const { RetrievalCascade, CascadeLevel } = await loadModule();
+    const teacher = makeTeacher({ confirmed: false, confidence: 0 });
+    const researcher = makeResearcher({ resolved: false, confidence: 0 });
+    const cascade = new RetrievalCascade(teacher, researcher, baseConfig);
+
+    const res = await cascade.run({ ...input, confidence: 0.9 });
+
+    expect(res.level).toBe(CascadeLevel.CLAIMKIT);
+    expect(res.outcome).toBe("ck_high_confidence");
+    expect(res.tokensUsed).toBe(0);
+    expect(teacher.verify).not.toHaveBeenCalled();
+    expect(researcher.research).not.toHaveBeenCalled();
+  });
+
+  it("stops at TEACHER_VERIFY when the teacher confirms a medium-confidence answer", async () => {
+    const { RetrievalCascade, CascadeLevel } = await loadModule();
+    const teacher = makeTeacher({ confirmed: true, confidence: 0.9, tokensUsed: 950 });
+    const researcher = makeResearcher({ resolved: true, confidence: 1 });
+    const cascade = new RetrievalCascade(teacher, researcher, baseConfig);
+
+    const res = await cascade.run({ ...input, confidence: 0.6 });
+
+    expect(res.level).toBe(CascadeLevel.TEACHER_VERIFY);
+    expect(res.outcome).toBe("teacher_confirmed");
+    expect(res.confidence).toBe(0.9);
+    expect(res.tokensUsed).toBe(950);
+    expect(teacher.verify).toHaveBeenCalledTimes(1);
+    expect(researcher.research).not.toHaveBeenCalled();
+  });
+
+  it("escalates to TOOL_RESEARCH when the teacher rejects, and stops on strong evidence", async () => {
+    const { RetrievalCascade, CascadeLevel } = await loadModule();
+    const teacher = makeTeacher({ confirmed: false, confidence: 0.2, tokensUsed: 900 });
+    const researcher = makeResearcher({ resolved: true, confidence: 0.85, tokensUsed: 1700 });
+    const cascade = new RetrievalCascade(teacher, researcher, baseConfig);
+
+    const res = await cascade.run({ ...input, confidence: 0.6 });
+
+    expect(res.level).toBe(CascadeLevel.TOOL_RESEARCH);
+    expect(res.outcome).toBe("tool_confirmed");
+    expect(res.confidence).toBe(0.85);
+    expect(res.tokensUsed).toBe(900 + 1700);
+    expect(teacher.verify).toHaveBeenCalledTimes(1);
+    expect(researcher.research).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the teacher for below-medium confidence and goes straight to research", async () => {
+    const { RetrievalCascade, CascadeLevel } = await loadModule();
+    const teacher = makeTeacher({ confirmed: true, confidence: 1 });
+    const researcher = makeResearcher({ resolved: true, confidence: 0.9, tokensUsed: 1500 });
+    const cascade = new RetrievalCascade(teacher, researcher, baseConfig);
+
+    const res = await cascade.run({ ...input, confidence: 0.3 });
+
+    expect(res.level).toBe(CascadeLevel.TOOL_RESEARCH);
+    expect(teacher.verify).not.toHaveBeenCalled();
+    expect(researcher.research).toHaveBeenCalledTimes(1);
+    expect(res.tokensUsed).toBe(1500);
+  });
+
+  it("falls back to FULL_RAG when neither teacher nor research resolve the query", async () => {
+    const { RetrievalCascade, CascadeLevel } = await loadModule();
+    const teacher = makeTeacher({ confirmed: false, confidence: 0.1, tokensUsed: 800 });
+    const researcher = makeResearcher({ resolved: false, confidence: 0.2, tokensUsed: 1600 });
+    const cascade = new RetrievalCascade(teacher, researcher, baseConfig);
+
+    const res = await cascade.run({ ...input, confidence: 0.6 });
+
+    expect(res.level).toBe(CascadeLevel.FULL_RAG);
+    expect(res.outcome).toBe("fell_back_to_rag");
+    expect(res.tokensUsed).toBe(800 + 1600);
+  });
+
+  it("falls back to FULL_RAG (budget_exhausted) when the teacher step can't be afforded", async () => {
+    const { RetrievalCascade, CascadeLevel } = await loadModule();
+    const teacher = makeTeacher({ confirmed: true, confidence: 1 });
+    const researcher = makeResearcher({ resolved: true, confidence: 1 });
+    const cascade = new RetrievalCascade(teacher, researcher, { ...baseConfig, budgetTokens: 500 });
+
+    const res = await cascade.run({ ...input, confidence: 0.6 });
+
+    expect(res.level).toBe(CascadeLevel.FULL_RAG);
+    expect(res.outcome).toBe("budget_exhausted");
+    expect(res.tokensUsed).toBe(0);
+    expect(teacher.verify).not.toHaveBeenCalled();
+  });
+
+  it("stops before TOOL_RESEARCH when the teacher spend leaves no room in the budget", async () => {
+    const { RetrievalCascade, CascadeLevel } = await loadModule();
+    const teacher = makeTeacher({ confirmed: false, confidence: 0.1, tokensUsed: 900 });
+    const researcher = makeResearcher({ resolved: true, confidence: 1 });
+    // Budget fits the teacher (1000) but not teacher-spend + tool cost (2000).
+    const cascade = new RetrievalCascade(teacher, researcher, { ...baseConfig, budgetTokens: 1500 });
+
+    const res = await cascade.run({ ...input, confidence: 0.6 });
+
+    expect(res.level).toBe(CascadeLevel.FULL_RAG);
+    expect(res.outcome).toBe("budget_exhausted");
+    expect(teacher.verify).toHaveBeenCalledTimes(1);
+    expect(researcher.research).not.toHaveBeenCalled();
+  });
+
+  it("treats a confirmed-but-not-confident teacher verdict as a rejection", async () => {
+    const { RetrievalCascade, CascadeLevel } = await loadModule();
+    const teacher = makeTeacher({ confirmed: true, confidence: 0.5, tokensUsed: 900 });
+    const researcher = makeResearcher({ resolved: true, confidence: 0.9, tokensUsed: 1500 });
+    const cascade = new RetrievalCascade(teacher, researcher, baseConfig);
+
+    const res = await cascade.run({ ...input, confidence: 0.6 });
+
+    expect(res.level).toBe(CascadeLevel.TOOL_RESEARCH);
+    expect(researcher.research).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("parseTeacherVerdict", () => {
+  it("parses a clean JSON confirm verdict", async () => {
+    const { parseTeacherVerdict } = await loadModule();
+    expect(parseTeacherVerdict('{"verdict":"confirm","confidence":0.9}')).toEqual({
+      confirmed: true,
+      confidence: 0.9,
+    });
+  });
+
+  it("parses a reject verdict with surrounding prose", async () => {
+    const { parseTeacherVerdict } = await loadModule();
+    const out = parseTeacherVerdict('Here is my answer: {"verdict":"reject","confidence":0.2} done');
+    expect(out.confirmed).toBe(false);
+    expect(out.confidence).toBeCloseTo(0.2);
+  });
+
+  it("clamps out-of-range confidences", async () => {
+    const { parseTeacherVerdict } = await loadModule();
+    expect(parseTeacherVerdict('{"verdict":"confirm","confidence":5}').confidence).toBe(1);
+  });
+
+  it("falls back to a keyword heuristic for non-JSON output", async () => {
+    const { parseTeacherVerdict } = await loadModule();
+    expect(parseTeacherVerdict("I confirm this is correct").confirmed).toBe(true);
+    expect(parseTeacherVerdict("this looks wrong").confirmed).toBe(false);
+  });
+
+  it("returns a safe default for empty input", async () => {
+    const { parseTeacherVerdict } = await loadModule();
+    expect(parseTeacherVerdict("")).toEqual({ confirmed: false, confidence: 0 });
+  });
+});
+
+describe("scoreEvidenceSupport", () => {
+  it("returns 0 when there is no evidence", async () => {
+    const { scoreEvidenceSupport } = await loadModule();
+    expect(scoreEvidenceSupport("anything", "", 0)).toBe(0);
+  });
+
+  it("scores by keyword overlap with the candidate answer", async () => {
+    const { scoreEvidenceSupport } = await loadModule();
+    const score = scoreEvidenceSupport(
+      "deploy script runs migrations",
+      "the deploy script runs database migrations nightly",
+      3,
+    );
+    expect(score).toBeGreaterThanOrEqual(0.8);
+  });
+
+  it("uses a result-count signal when there is no candidate answer", async () => {
+    const { scoreEvidenceSupport } = await loadModule();
+    expect(scoreEvidenceSupport("", "some evidence text", 3)).toBeCloseTo(0.7);
+    expect(scoreEvidenceSupport("", "some evidence text", 0)).toBe(0);
+  });
+});
+
+describe("createDefaultTeacherVerifier", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnv.CASCADE_TEACHER_MODEL = "";
+  });
+
+  it("confirms via a JSON-mode chat call and reports usage tokens", async () => {
+    const { createDefaultTeacherVerifier } = await loadModule();
+    mockChat.mockResolvedValue({
+      content: '{"verdict":"confirm","confidence":0.95}',
+      usage: { totalTokens: 1234 },
+    });
+
+    const verifier = createDefaultTeacherVerifier();
+    const verdict = await verifier.verify({ ...input, confidence: 0.6 });
+
+    expect(verdict.confirmed).toBe(true);
+    expect(verdict.confidence).toBe(0.95);
+    expect(verdict.tokensUsed).toBe(1234);
+    expect(mockChat).toHaveBeenCalledWith(
+      expect.objectContaining({ jsonMode: true, temperature: 0 }),
+    );
+  });
+
+  it("passes CASCADE_TEACHER_MODEL to the chat call when set", async () => {
+    mockEnv.CASCADE_TEACHER_MODEL = "glm-5.1:cloud";
+    const { createDefaultTeacherVerifier } = await loadModule();
+    mockChat.mockResolvedValue({ content: '{"verdict":"reject","confidence":0.1}' });
+
+    await createDefaultTeacherVerifier().verify({ ...input, confidence: 0.6 });
+
+    expect(mockChat).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "glm-5.1:cloud" }),
+    );
+  });
+
+  it("estimates tokens when the provider omits usage", async () => {
+    const { createDefaultTeacherVerifier } = await loadModule();
+    mockChat.mockResolvedValue({ content: '{"verdict":"confirm","confidence":0.9}' });
+
+    const verdict = await createDefaultTeacherVerifier().verify({ ...input, confidence: 0.6 });
+    expect(verdict.tokensUsed).toBeGreaterThan(0);
+  });
+
+  it("returns a safe rejection when the chat call throws", async () => {
+    const { createDefaultTeacherVerifier } = await loadModule();
+    mockChat.mockRejectedValue(new Error("provider down"));
+
+    const verdict = await createDefaultTeacherVerifier().verify({ ...input, confidence: 0.6 });
+    expect(verdict).toEqual({ confirmed: false, confidence: 0, tokensUsed: 0 });
+  });
+});
+
+describe("createDefaultToolResearcher", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns unresolved when web search is not configured", async () => {
+    const { createDefaultToolResearcher } = await loadModule();
+    mockWebIsConfigured.mockReturnValue(false);
+
+    const result = await createDefaultToolResearcher().research({ ...input, confidence: 0.3 });
+    expect(result).toEqual({ resolved: false, confidence: 0, evidence: "", tokensUsed: 0 });
+    expect(mockWebSearch).not.toHaveBeenCalled();
+  });
+
+  it("corroborates the answer from search snippets", async () => {
+    const { createDefaultToolResearcher } = await loadModule();
+    mockWebIsConfigured.mockReturnValue(true);
+    mockWebSearch.mockResolvedValue({
+      query: "q",
+      answer: "Run deploy.sh to deploy",
+      results: [{ title: "t", url: "u", snippet: "the deploy.sh script handles deploy" }],
+      totalResults: 1,
+      provider: "tavily",
+    });
+
+    const result = await createDefaultToolResearcher().research({
+      query: "how to deploy",
+      claimKitAnswer: "Run deploy.sh deploy",
+      confidence: 0.3,
+    });
+
+    expect(result.resolved).toBe(true);
+    expect(result.confidence).toBeGreaterThan(0);
+    expect(result.evidence).toContain("deploy.sh");
+  });
+
+  it("returns a safe unresolved result when search throws", async () => {
+    const { createDefaultToolResearcher } = await loadModule();
+    mockWebIsConfigured.mockReturnValue(true);
+    mockWebSearch.mockRejectedValue(new Error("network"));
+
+    const result = await createDefaultToolResearcher().research({ ...input, confidence: 0.3 });
+    expect(result).toEqual({ resolved: false, confidence: 0, evidence: "", tokensUsed: 0 });
+  });
+});
+
+describe("createDefaultCascade", () => {
+  it("builds a cascade configured from env with optional overrides", async () => {
+    const { createDefaultCascade, RetrievalCascade } = await loadModule();
+    const cascade = createDefaultCascade({ budgetTokens: 9999 });
+    expect(cascade).toBeInstanceOf(RetrievalCascade);
+  });
+});


### PR DESCRIPTION
Closes #245

_Generated by AiRemoteCoder autonomous agent._